### PR TITLE
Change download function

### DIFF
--- a/pycrucible/pycrucible.py
+++ b/pycrucible/pycrucible.py
@@ -133,6 +133,12 @@ class CrucibleClient:
             output_path = Path(output_path)
             if output_path.is_dir():
                 output_path = output_path / Path(file_name)
+
+        # Check if file already exists (caching)
+        skip = False
+        if output_path.exists() and 'sha256_hash' in dataset:
+            if checkhash(output_path) == dataset['sha256_hash']:
+                skip = True
         
         # Check if file already exists (caching)
         if os.path.exists(output_path):

--- a/pycrucible/pycrucible.py
+++ b/pycrucible/pycrucible.py
@@ -1,3 +1,5 @@
+from pathlib import Path
+
 import os
 import time
 import requests
@@ -110,6 +112,9 @@ class CrucibleClient:
             dsid: Dataset ID
             file_name: Name of file to download. If not provided, uses dataset's file_to_upload field
             output_path: Local path to save file. If not provided, uses the file_name in current directory
+
+        Returns:
+            str: A message including the path to the downloaded file
         """
         # If no file_name specified, get it from the dataset's file_to_upload field
         dataset = self.get_dataset(dsid)
@@ -122,8 +127,12 @@ class CrucibleClient:
         
         # Set default output path if not provided
         if output_path is None:
-            output_path = os.path.join('crucible-downloads', file_name)
-            os.makedirs('crucible-downloads', exist_ok = True)
+            output_path = (Path('./crucible-downloads') / Path(file_name))
+            output_path.parent.mkdir(exist_ok=True)
+        elif isinstance(output_path, str):
+            output_path = Path(output_path)
+            if output_path.is_dir():
+                output_path = output_path / Path(file_name)
         
         # Check if file already exists (caching)
         if os.path.exists(output_path):


### PR DESCRIPTION
I changed the download function to do a few different things:
1) Use `pathlib`. Its a little easier to use compared to `os.path` and strings
2) Allow `output_path` to be a directory so you can save the file where you want
3)  Check for file existence, hash existence, and compare file hashes. Some datasets do not have a hash or a different hash keyword. Skip download if all of those are True.
4) Download the file and save to disk. You only need to write the `content`. No need to iterate. This might speed things up a bit especially for large files. However, maybe larger files need to iterate? We can test this if needed.

During testing, I see that download of a 6 MB file is about 1 sec and saving is about 0.001 sec. So, the download is the bottleneck.