### PR TITLE
add_thumbnail can take an already encoded string

### DIFF
--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -543,7 +543,7 @@ class DatasetOperations(BaseResource):
         Args:
             dsid (str): Dataset unique identifier
             image: Image to use as thumbnail. Accepts:
-                - str or Path: path to an image file
+                - str or Path: path to an image file or a base64-encoded image string
                 - PIL.Image.Image: PIL image object
                 - matplotlib.figure.Figure: matplotlib figure
                 - numpy.ndarray: array of shape (H, W) or (H, W, C)

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -554,7 +554,14 @@ class DatasetOperations(BaseResource):
             Dict: Created thumbnail object
         """
         import base64
-        from ..utils import data2thumbnail
+        from ..utils import data2thumbnail, is_base64
+
+        if is_base64(image):
+            thumbnail_data = {
+                'thumbnail_name': thumbnail_name or f"{dsid}_thumbnail",
+                'thumbnail_b64str': image,
+            }
+            return self._request('post', f'/datasets/{dsid}/thumbnails', json=thumbnail_data)
 
         png_path = data2thumbnail(image)
 

--- a/crucible/utils/__init__.py
+++ b/crucible/utils/__init__.py
@@ -9,7 +9,7 @@ io          : File I/O, hashing, time, and image helpers
 deprecation : API lifecycle decorators (_deprecated, _removed)
 """
 
-from .io import run_shell, checkhash, get_tz_isoformat, check_small_files, data2thumbnail, parse_timestamp
+from .io import run_shell, checkhash, get_tz_isoformat, check_small_files, is_base64, data2thumbnail, parse_timestamp
 from .deprecation import _deprecated, _removed
 
 __all__ = [
@@ -19,6 +19,7 @@ __all__ = [
     'get_tz_isoformat',
     'parse_timestamp',
     'check_small_files',
+    'is_base64',
     'data2thumbnail',
     # deprecation
     '_deprecated',

--- a/crucible/utils/io.py
+++ b/crucible/utils/io.py
@@ -4,6 +4,7 @@
 File I/O, hashing, time, and image utilities.
 """
 
+import base64
 import os
 import pytz
 import subprocess as sp
@@ -127,6 +128,12 @@ def check_small_files(filelist):
             return False
     return True
 
+def is_base64(s):
+      try:
+          base64.b64decode(s, validate=True)
+          return True
+      except Exception:
+          return False
 
 def data2thumbnail(image) -> str:
     """Convert an image object to a path to a PNG file.


### PR DESCRIPTION
- Update datasets.add_thumbnail to check if provided string is base64 encoded
- If True, make API request directly; otherwise treat as file path
- Updated utils to add the is_base64 check function