### PR TITLE
Modularize create

### DIFF
--- a/crucible/client.py
+++ b/crucible/client.py
@@ -149,7 +149,7 @@ class CrucibleClient:
         while req_info['status'] in ['requested', 'started']:
             time.sleep(sleep_interval)
             req_info = self._get_request_status(dsid, reqid, request_type)
-            logger.debug(f"Current status: {req_info['status']}")
+            logger.info(f"Current status: {req_info['status']}")
 
         logger.info(f"Request completed with status: {req_info['status']}")
         return req_info

--- a/crucible/models.py
+++ b/crucible/models.py
@@ -10,26 +10,6 @@ from typing import Dict, List, Optional
 #%% Models
 
 class Sample(BaseModel):
-    '''
-    Physical or computational sample. Samples can form many to many relationships
-    with samples and other datasets to capture parent-child relationships and 
-    information about the sample synthesis or measured properties. 
-
-    Attributes:                                                                                                                                                                                                                                                                                        
-         unique_id: System-assigned unique identifier for the sample generated with the mfid package.                                                                                                                                                                                                                               
-         sample_name: Human-readable name.                                                                                                                                                                                                                                                              
-         sample_type: Categorical label (e.g., ``"substrate"``, ``"thin film"``). Currently this allows any string.  It is recommended to use consistent sample types within a project.                                                                                                                                                                                                                
-         owner_orcid: ORCID of the person who owns this sample.                                                                                                                                                                                                                                     
-         timestamp: User-settable date for the sample (ISO 8601). Also accepted                                                                                                                                                                                                                         
-             as ``date_created`` from legacy API responses.                                                                                                                                                                                                                                             
-         creation_time: Server-assigned creation timestamp (read-only).                                                                                                                                                                                                                                 
-         modification_time: Server-assigned last-modification timestamp (read-only).                                                                                                                                                                                                                    
-         project_id: ID of the project this sample belongs to.                                                                                                                                                                                                                                          
-         description: Free-text description of the sample.                                                                                                                                                                                                                                              
-         links: Raw list of link objects returned by the API when                                                                                                                                                                                                                                       
-             ``include_links=True`` is passed to the get endpoint. 
-
-    '''
     unique_id: Optional[str] = None
     sample_name: Optional[str] = None
     sample_type: Optional[str] = None
@@ -52,9 +32,6 @@ class Sample(BaseModel):
 
 
 class Dataset(BaseModel):
-    '''
-    Dataset record plus optional file payload. 
-    '''
     unique_id: Optional[str] = None
     dataset_name: Optional[str] = None
     public: Optional[bool] = False
@@ -82,21 +59,6 @@ class Dataset(BaseModel):
     model_config = ConfigDict(from_attributes=True, populate_by_name=True, extra='allow')
 
 class Project(BaseModel):
-    '''
-    Represents a collection of related datasets and samples within the platform.
-    For user facilities, this roughly maps to a user proposal but can be used for other use cases as well. 
-    Projects are also used as access groups to control
-    which Crucible users have access to which datasets and samples. 
-
-    Attributes:
-        project_id: Unique but human-readable name for the project. (Historically this was the proposal_id with an organizational prefix, eg. MFP00000)
-        organization: Organization or institution leading the project.
-        project_lead_orcid: ORCID of the project lead. This is used to link the project to a user in the system and is required for project creation.
-        project_lead_email: Backward-compat field; not sent to the API.
-        status: Status of the project. (eg. "active", "completed").
-        title: Optional descriptive title for the project.
-        project_lead_name: Name of the project lead. This is populated based on the project_lead_orcid.
-    '''
     project_id: str
     organization: str
     project_lead_orcid: Optional[str] = None
@@ -109,17 +71,6 @@ class Project(BaseModel):
 
 
 class User(BaseModel):
-    '''
-    Model for Crucible platform users. Includes both human users and service accounts. 
-
-    Attributes:
-        id: Internal database ID for the user (read-only).
-        unique_id: Unique identifier for the user account. This is ORCID for human users and mfid-generated ID for service accounts.
-        first_name: First name of the user.
-        last_name: Last name of the user.
-        email: Email address of the user.
-        is_service_account: Whether this user account is a service account.
-    '''
     id: Optional[int] = None
     unique_id: Optional[str] = Field(
         default=None,
@@ -139,23 +90,6 @@ class User(BaseModel):
 
 
 class Instrument(BaseModel):
-    '''
-    The instrument used to collect or generate the data. 
-    Attributes:
-        unique_id: Unique identifier for the instrument generated with mfid.
-        instrument_name: Name of the instrument.
-        manufacturer: Manufacturer of the instrument.
-        model: Model of the instrument.
-        owner: Organizational owner of the instrument. (eg. LBNL MF NCEM for Lawrence Berkeley National Laboratory, Molecular Foundry, National Center for Electron Microscopy)
-        location: Physical location of the instrument. (eg. 72-123 for Building 72, room 123 at LBNL)
-        description: Free-text description of the instrument.
-        instrument_type: Categorical label for the type of instrument. Currently not restrictive.
-        other_id: Optional field for storing an additional identifier for the instrument (eg. an internal inventory ID or a Research Resource Identifier (RRID)).
-        other_id_source: If other_id is used, this field can be used to specify the source or type of the other_id (eg. "internal_inventory", "RRID").
-        resource_type: The type of resource. This will be set to "instrument" for instrument records.
-        creation_time: Server-assigned creation timestamp (read-only).
-        modification_time: Server-assigned last-modification timestamp (read-only).
-    '''
     # id: Optional[int] = None
     unique_id: Optional[str] = None
     instrument_name: Optional[str] = None
@@ -177,21 +111,7 @@ class Instrument(BaseModel):
 
 class DeletionRequest(BaseModel):
     '''
-    A pending or resolved request to delete a resource. Status is one of pending, approved, or rejected.
-    Multiple deletion requests can be made for the same resource. Pending deletion requests will not
-    appear in search results, but will still exist in the database until approved.
-
-    Attributes:
-        resource_type: The type of resource to be deleted ("dataset", "sample", "project", "instrument")
-        resource_id: The unique identifier (mfid) of the resource to be deleted
-        resource_name: The human-readable name of the resource to be deleted (for reference only; not used by the API)
-        requester_id: The unique identifier (orcid or service account) of the user who made the deletion request
-        reason: The reason provided by the requester for why the resource should be deleted
-        status: The status of the deletion request ("pending", "approved", "rejected")
-        request_time: Timestamp of when the deletion request was made (ISO 8601)
-        review_time: Timestamp of when the deletion request was reviewed (ISO 8601; null if still pending)
-        reviewer_id: The unique identifier (orcid or service account) of the user who reviewed the deletion request (null if still pending)
-        reviewer_notes: Optional notes provided by the reviewer when approving or rejecting the deletion request
+    A pending or resolved request to delete a resource. 
     '''  
 
     # id: Optional[int] = None
@@ -207,6 +127,7 @@ class DeletionRequest(BaseModel):
     reviewer_notes: Optional[str] = None
 
     model_config = ConfigDict(from_attributes=True, populate_by_name=True, extra='allow')
+
 
 
 #%% Backward-compatibility aliases (deprecated)

--- a/crucible/models.py
+++ b/crucible/models.py
@@ -72,9 +72,9 @@ class Dataset(BaseModel):
     creation_time: Optional[str] = None
     modification_time: Optional[str] = None
     data_format: Optional[str] = None
-    file_to_upload: Optional[str] = None
+    #file_to_upload: Optional[str] = None
     size: Optional[int] = None
-    sha256_hash_file_to_upload: Optional[str] = None
+    #sha256_hash_file_to_upload: Optional[str] = None
     source_folder: Optional[str] = None
     scientific_metadata: Optional[Dict] = None
     links: Optional[List[Dict]] = None

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -6,6 +6,7 @@ Dataset resource operations for Crucible API.
 Provides organized access to dataset-related API endpoints.
 """
 
+from fileinput import filename
 import os
 import re
 import fnmatch
@@ -98,26 +99,15 @@ class DatasetOperations(BaseResource):
 
 
     def create(self, dataset, scientific_metadata: Optional[Dict] = None,
-               keywords: Optional[List[str]] = None,
-               get_user_info_function=None, verbose: bool = False,
-               files_to_upload: Optional[List[str]] = None,
-               ingestor: str = 'ApiUploadIngestor',
-               wait_for_ingestion_response: bool = True) -> Dict:
+               keywords: Optional[List[str]] = None) -> Dict:
         """Create a new dataset with metadata and optionally upload files.
 
         Args:
             dataset: Dataset object with dataset details
             scientific_metadata (dict, optional): Scientific metadata
             keywords (list, optional): Keywords to associate with dataset
-            get_user_info_function (callable, optional): Function to get user info
-            verbose (bool): Enable verbose output
-            files_to_upload (List[str], optional): List of file paths to upload
-            ingestor (str): Ingestion class to use (default: 'ApiUploadIngestor')
-            wait_for_ingestion_response (bool): Wait for ingestion to complete
-
         Returns:
-            Dict: created_record, scientific_metadata_record, dsid, and optionally
-                  uploaded_files and ingestion_request if files_to_upload provided
+            Dict: created_record, scientific_metadata_record, dsid
         """
         if scientific_metadata is None:
             scientific_metadata = {}
@@ -125,35 +115,12 @@ class DatasetOperations(BaseResource):
         if keywords is None:
             keywords = []
 
-        dataset_details = dict(**dataset.model_dump())
-
-        # Handle file upload path if files provided
-        if files_to_upload:
-            logger.debug(f'files_to_upload={files_to_upload}')
-            main_file = dataset_details.get('file_to_upload')
-            logger.debug(f'main_file from dataset_details: {main_file}')
-            if not main_file:
-                main_file = files_to_upload[0]
-                logger.debug(f'main_file from files_to_upload: {main_file}')
-            base_file_name = os.path.basename(main_file)
-            logger.debug(f'base_file_name={base_file_name}')
-            main_file_cloud = os.path.join(f'api-uploads/{base_file_name}')
-            dataset_details['file_to_upload'] = main_file_cloud
-            logger.debug(f'main_file_cloud={main_file_cloud}')
-
-            # auto-set timestamp from file modification time if not provided
-            if dataset_details.get('timestamp') is None:
-                import datetime
-                mtime = os.path.getmtime(main_file)
-                dataset_details['timestamp'] = datetime.datetime.fromtimestamp(
-                    mtime, tz=datetime.timezone.utc).isoformat()
+        dataset_details = dataset.model_dump()
 
         logger.debug('Creating new dataset record...')
 
         clean_dataset = {k: v for k, v in dataset_details.items() if v is not None}
-        logger.debug(f'POST request to /datasets with {clean_dataset}')
         new_ds_record = self._request('post', '/datasets', json=clean_dataset)
-        logger.debug('Request complete')
         dsid = new_ds_record['unique_id']
 
         # add scientific metadata
@@ -161,7 +128,7 @@ class DatasetOperations(BaseResource):
         if scientific_metadata is not None:
             logger.debug(f'Adding scientific metadata record for {dsid}')
             scimd = self.add_scientific_metadata(dsid, scientific_metadata)
-            logger.debug('Metadata addition complete')
+
             
         # add keywords
         if keywords:
@@ -169,48 +136,82 @@ class DatasetOperations(BaseResource):
             for kw in keywords:
                 self.add_keyword(dsid, kw)
 
-        logger.debug(f"dsid={dsid}")
-
         result = {"created_record": new_ds_record, "scientific_metadata_record": scimd, "dsid": dsid}
-        if not files_to_upload:
-            return result
-        
-        #  === File Upload
-        failed_files = {}
-        uploaded_files = []
-
-        for each_file in files_to_upload:
-            if not os.path.isfile(each_file):
-                failed_files[each_file] = f"File not found"
-                continue
-
-            resp = self.upload_file(dsid, each_file)
-            if resp is None:
-                failed_files[each_file] = "Exceeds maximum size for API upload"
-                continue
-            else:
-                uploaded_files.append(resp)
-
-        if failed_files:
-            ingestion_command = f"client.datasets.request_ingestion('{dsid}', file_to_upload='{main_file_cloud}', ingestion_class='{ingestor}')"
-            logger.error(f"Some files failed to upload for dataset {dsid}: {failed_files}")
-            logger.info(f"Please upload these files manually and then request ingestion: {ingestion_command}")
-            raise RuntimeError(f"File upload failed for dataset {dsid}.\n\nFailed files: {failed_files}.\n\nPlease upload these files manually and then request ingestion: {ingestion_command}")
-        
-        # Ingestion
-        logger.debug(f"Submitting {dsid} to be ingested from file {main_file_cloud} using the class {ingestor}")
-
-        ingest_req_info = self.request_ingestion(dsid, main_file_cloud, ingestor)
-
-        logger.debug(f"Ingestion request {ingest_req_info['id']} is added to the queue")
-
-        if wait_for_ingestion_response:
-            ingest_req_info = self._client._wait_for_request_completion(dsid, ingest_req_info['id'], 'ingest')
-
-        result["uploaded_files"] = uploaded_files
-        result["ingestion_request"] = ingest_req_info
-
         return result
+
+    # Associated Files Methods
+    def get_associated_files(self, dsid: str, limit: int = DEFAULT_LIMIT) -> List[Dict]:
+        """Get associated files for a dataset.
+
+        Args:
+            dsid (str): Dataset unique identifier
+            limit (int): Maximum number of results to return
+
+        Returns:
+            List[Dict]: File metadata with names, sizes, and hashes
+        """
+        return self._request('get', f'/datasets/{dsid}/associated_files')
+
+    def add_file_to_dataset(self, dsid: str, file_path: str, ingestion_class: Optional[str] = None, wait_for_ingestion_response: bool = False) -> Dict:
+        """Add an associated file to a dataset.
+
+        Args:
+            dsid (str): Dataset unique identifier
+            file_path (str): Path to file (for calculating metadata)
+            ingestion_class (str, optional): Ingestion class to use for this file (e.g. 'ApiUploadIngestor') If None, ingestors will be scanned to find a match based on file format.
+
+        Returns:
+            Dict: Associated file record and Ingestion request.
+        """
+        from ..utils import checkhash
+
+        # Calculate file metadata
+        file_size = os.path.getsize(file_path)
+        if file_size >= 1e8:
+            raise RuntimeError(f"File {file_path} is too large for API upload ({file_size} bytes).")
+        
+        file_hash = checkhash(file_path)
+        filename = os.path.basename(file_path)
+
+        # upload
+        upload_status = self._upload_file(dsid, file_path)
+        if upload_status is None:
+            raise RuntimeError(f"Failed to upload {file_path}. File may be too large. ")
+        
+        # add associated file record to database + request ingestion
+        associated_file_data = {
+            'filename': filename,
+            'size': file_size,
+            'sha256_hash': file_hash,
+            'ingestion_class': ingestion_class
+        }
+        response = self._request('post', f'/datasets/{dsid}/associated_files', json=associated_file_data)
+        if wait_for_ingestion_response:
+            ingestion_request = response.get('ingestion_request')
+            status = self._client._wait_for_request_completion(dsid, ingestion_request['id'], 'ingest')
+
+        return response
+
+    def _upload_file(self, dsid: str, file_path: str) -> Dict:
+        """Upload a file to a dataset.
+
+        Args:
+            dsid (str): Dataset unique identifier
+            file_path (str): Local path to file to upload
+
+        Returns:
+            Dict: Upload response
+        """
+        logger.debug(f"Uploading file {file_path}...")
+        with open(file_path, 'rb') as f:
+            fname = os.path.basename(file_path)
+            files = [('files', (fname, f, 'application/octet-stream'))]
+            added_af = self._request('post', f'/datasets/{dsid}/upload', files=files)
+            return added_af
+            
+        logger.error(f"{file_path} is too large for HTTP upload via the Crucible API. Please upload manually.")
+        return None
+
     
     def update(self, dsid: str, **updates) -> Dict:
         """Update an existing dataset with new field values.
@@ -269,31 +270,6 @@ class DatasetOperations(BaseResource):
         """
         params = {"group_name": group_name, "read": read, "write": write}
         return self._request('post', f'/datasets/{dsid}/access_groups', params=params)
-
-
-    def upload_file(self, dsid: str, file_path: str) -> Dict:
-        """Upload a file to a dataset.
-
-        Args:
-            dsid (str): Dataset unique identifier
-            file_path (str): Local path to file to upload
-
-        Returns:
-            Dict: Upload response
-        """
-        logger.debug(f"Uploading file {file_path}...")
-        use_upload_endpoint = check_small_files([file_path])
-
-        if use_upload_endpoint:
-            with open(file_path, 'rb') as f:
-                fname = os.path.basename(file_path)
-                files = [('files', (fname, f, 'application/octet-stream'))]
-                added_af = self._request('post', f'/datasets/{dsid}/upload', files=files)
-                return added_af
-            
-        logger.error(f"{file_path} is too large for HTTP upload via the Crucible API. Please upload manually.")
-        return None
-
 
     def get_download_links(self, dsid: str) -> Dict:
         """Get the download links for files in a given dataset.
@@ -396,28 +372,6 @@ class DatasetOperations(BaseResource):
                                      no_record=no_record,
                                      overwrite_existing=overwrite_existing,
                                      include=include, exclude=exclude)
-
-    def request_ingestion(self, dsid: str, file_to_upload: Optional[str] = None,
-                         ingestion_class: Optional[str] = None,
-                         wait_for_response: bool = False) -> Dict:
-        """Request dataset ingestion.
-
-        Args:
-            dsid (str): Dataset unique identifier
-            file_to_upload (str, optional): Path to file for ingestion
-            ingestion_class (str, optional): Ingestion class to use
-            wait_for_response (bool): Wait for ingestion to complete
-
-        Returns:
-            Dict: Ingestion request with id and status
-        """
-        params = {"ingestion_class": ingestion_class, "file_to_upload": file_to_upload}
-        logger.debug(f"Ingestion params: {params}")
-        req_info = self._request('post', f'/datasets/{dsid}/ingest', params=params)
-        if wait_for_response:
-            req_info = self._client._wait_for_request_completion(dsid, req_info['id'], 'ingest')
-
-        return req_info
 
     @_deprecated("create() with files_to_upload parameter")
     def create_from_files(self, dataset, files_to_upload: List[str],
@@ -569,46 +523,6 @@ class DatasetOperations(BaseResource):
         }
         return self._request('post', f'/datasets/{dsid}/thumbnails', json=thumbnail_data)
 
-    # Associated Files Methods
-    def get_associated_files(self, dsid: str, limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Get associated files for a dataset.
-
-        Args:
-            dsid (str): Dataset unique identifier
-            limit (int): Maximum number of results to return
-
-        Returns:
-            List[Dict]: File metadata with names, sizes, and hashes
-        """
-        return self._request('get', f'/datasets/{dsid}/associated_files')
-
-    def add_associated_file(self, dsid: str, file_path: str, filename: Optional[str] = None) -> Dict:
-        """Add an associated file to a dataset.
-
-        Args:
-            dsid (str): Dataset unique identifier
-            file_path (str): Path to file (for calculating metadata)
-            filename (str, optional): Filename to store (uses basename if not provided)
-
-        Returns:
-            Dict: Created associated file object
-        """
-        from ..utils import checkhash
-
-        # Calculate file metadata
-        file_size = os.path.getsize(file_path)
-        file_hash = checkhash(file_path)
-
-        # Use basename if no filename provided
-        if filename is None:
-            filename = os.path.basename(file_path)
-
-        associated_file_data = {
-            'filename': filename,
-            'size': file_size,
-            'sha256_hash': file_hash
-        }
-        return self._request('post', f'/datasets/{dsid}/associated_files', json=associated_file_data)
 
     # Keyword Methods
     def get_keywords(self, dsid: Optional[str] = None, limit: int = DEFAULT_LIMIT) -> List[Dict]:
@@ -655,8 +569,6 @@ class DatasetOperations(BaseResource):
         """
         if request_type == 'ingest':
             return self._request('get', f'/datasets/{dsid}/ingest/{reqid}')
-        elif request_type == 'scicat_update':
-            return self._request('get', f'/datasets/{dsid}/scicat_update/{reqid}')
         else:
             raise ValueError(f"Unsupported request_type: {request_type}")
 
@@ -786,7 +698,6 @@ class DatasetOperations(BaseResource):
         """
         result = self._request('post', f"/datasets/{dsid}/carrier_segmentation")
         return result
-
 
     def request_insitu_aggregation(self, dsid: str) -> Dict:
         """Request insitu spectroscopy data aggregation for a dataset.

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -100,7 +100,7 @@ class DatasetOperations(BaseResource):
 
     def create(self, dataset, scientific_metadata: Optional[Dict] = None,
                keywords: Optional[List[str]] = None) -> Dict:
-        """Create a new dataset with metadata and optionally upload files.
+        """Create a new dataset record with scientific metadata and keywords.
 
         Args:
             dataset: Dataset object with dataset details
@@ -140,20 +140,14 @@ class DatasetOperations(BaseResource):
         return result
 
     # Associated Files Methods
-    def get_associated_files(self, dsid: str, limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Get associated files for a dataset.
-
-        Args:
-            dsid (str): Dataset unique identifier
-            limit (int): Maximum number of results to return
-
-        Returns:
-            List[Dict]: File metadata with names, sizes, and hashes
-        """
-        return self._request('get', f'/datasets/{dsid}/associated_files')
-
     def add_file_to_dataset(self, dsid: str, file_path: str, ingestion_class: Optional[str] = None, wait_for_ingestion_response: bool = False) -> Dict:
-        """Add an associated file to a dataset.
+        """Add an associated file to a dataset. 
+           
+           The provided file will be uploaded to cloud storage,
+           linked to the dataset record, and ingested. 
+           
+           This function also calculates the size and sha256
+           hash of the file before uploading.
 
         Args:
             dsid (str): Dataset unique identifier
@@ -164,7 +158,6 @@ class DatasetOperations(BaseResource):
             Dict: Associated file record and Ingestion request.
         """
         from ..utils import checkhash
-
         # Calculate file metadata
         file_size = os.path.getsize(file_path)
         if file_size >= 1e8:
@@ -183,9 +176,8 @@ class DatasetOperations(BaseResource):
             'filename': upload_path,
             'size': file_size,
             'sha256_hash': file_hash,
-            'ingestion_class': ingestion_class
         }
-        response = self._request('post', f'/datasets/{dsid}/associated_files', json=associated_file_data)
+        response = self._request('post', f'/datasets/{dsid}/associated_files', json=associated_file_data, params = {'ingestion_class': ingestion_class})
         if wait_for_ingestion_response:
             ingestion_request = response.get('ingestion_request')
             status = self._client._wait_for_request_completion(dsid, ingestion_request['id'], 'ingest')
@@ -213,7 +205,20 @@ class DatasetOperations(BaseResource):
         logger.error(f"{file_path} is too large for HTTP upload via the Crucible API. Please upload manually.")
         return None
 
-    
+
+    def get_associated_files(self, dsid: str, limit: int = DEFAULT_LIMIT) -> List[Dict]:
+        """Get associated files for a dataset.
+
+        Args:
+            dsid (str): Dataset unique identifier
+            limit (int): Maximum number of results to return
+
+        Returns:
+            List[Dict]: File metadata with names, sizes, and hashes
+        """
+        return self._request('get', f'/datasets/{dsid}/associated_files')
+
+
     def update(self, dsid: str, **updates) -> Dict:
         """Update an existing dataset with new field values.
 

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -99,7 +99,9 @@ class DatasetOperations(BaseResource):
 
 
     def create(self, dataset, scientific_metadata: Optional[Dict] = None,
-               keywords: Optional[List[str]] = None) -> Dict:
+               keywords: Optional[List[str]] = None, 
+               files_to_upload: Optional[List[str]] = [],
+               wait_for_ingestion_response = False) -> Dict:
         """Create a new dataset record with scientific metadata and keywords.
 
         Args:
@@ -135,6 +137,10 @@ class DatasetOperations(BaseResource):
             logger.debug(f'Adding keywords to dataset {dsid}: {keywords}')
             for kw in keywords:
                 self.add_keyword(dsid, kw)
+
+        for file in files_to_upload:
+            logger.debug(f'Adding {file} to dataset {dsid}')
+            self.add_file_to_dataset(dsid, file, ingestion_class = None, wait_for_ingestion_response = wait_for_ingestion_response)
 
         result = {"created_record": new_ds_record, "scientific_metadata_record": scimd, "dsid": dsid}
         return result

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -172,15 +172,15 @@ class DatasetOperations(BaseResource):
         
         file_hash = checkhash(file_path)
         filename = os.path.basename(file_path)
-
+        
         # upload
-        upload_status = self._upload_file(dsid, file_path)
-        if upload_status is None:
-            raise RuntimeError(f"Failed to upload {file_path}. File may be too large. ")
+        upload_path = self._upload_file(dsid, file_path)
+        if upload_path is None:
+            raise RuntimeError(f"Failed to upload {file_path}.")
         
         # add associated file record to database + request ingestion
         associated_file_data = {
-            'filename': filename,
+            'filename': upload_path,
             'size': file_size,
             'sha256_hash': file_hash,
             'ingestion_class': ingestion_class
@@ -191,6 +191,7 @@ class DatasetOperations(BaseResource):
             status = self._client._wait_for_request_completion(dsid, ingestion_request['id'], 'ingest')
 
         return response
+
 
     def _upload_file(self, dsid: str, file_path: str) -> Dict:
         """Upload a file to a dataset.
@@ -205,9 +206,9 @@ class DatasetOperations(BaseResource):
         logger.debug(f"Uploading file {file_path}...")
         with open(file_path, 'rb') as f:
             fname = os.path.basename(file_path)
-            files = [('files', (fname, f, 'application/octet-stream'))]
-            added_af = self._request('post', f'/datasets/{dsid}/upload', files=files)
-            return added_af
+            file_obj = [('files', (fname, f, 'application/octet-stream'))]
+            uploaded_file = self._request('post', f'/datasets/{dsid}/upload', files=file_obj)
+            return uploaded_file
             
         logger.error(f"{file_path} is too large for HTTP upload via the Crucible API. Please upload manually.")
         return None
@@ -572,8 +573,9 @@ class DatasetOperations(BaseResource):
         else:
             raise ValueError(f"Unsupported request_type: {request_type}")
 
-    def update_ingestion_status(self, dsid: str, reqid: str, status: str,
-                               timezone: str = "America/Los_Angeles"):
+    def update_ingestion_status(self, dsid: str, reqid: str, status: str, 
+                                ingestion_githash: str, ingestion_class: str,
+                                timezone: str = "America/Los_Angeles"):
         """Update the status of a dataset ingestion request.
 
         **Requires admin permissions.**
@@ -589,14 +591,15 @@ class DatasetOperations(BaseResource):
         """
         from ..utils import get_tz_isoformat
 
+        patch_json = {'ingestion_githash': ingestion_githash, 
+                      'ingestion_class': ingestion_class}
+        
         if status == "complete":
             completion_time = get_tz_isoformat(timezone)
-            patch_json = {"id": reqid,
-                        "status": status,
-                        "time_completed": completion_time}
+            patch_json.update({"id": reqid, "status": status,
+                        "time_completed": completion_time})
         else:
-            patch_json = {"id": reqid,
-                        "status": status}
+            patch_json.update({"id": reqid, "status": status})
 
         return self._request('patch', f'/datasets/{dsid}/ingest/{reqid}', json=patch_json)
 


### PR DESCRIPTION
datasets.create only calls post /datasets, /scientific_metadata, and /keywords.  Associated files can be added with datasets.add_file_to_dataset.  The new add_file_to_dataset function will calculate the size and hash of the file, upload the file to cloud storage (via the API), and call post /datasets/{dsid}/associated_file.  That endpoint updates the sql and requests the ingestion. 