### PR TITLE
Use API email param for project remove_user

### DIFF
--- a/crucible/resources/projects.py
+++ b/crucible/resources/projects.py
@@ -177,11 +177,9 @@ class ProjectOperations(BaseResource):
         """
         if not orcid and not email:
             raise ValueError("provide either orcid or email")
-        if not orcid:
-            user = self._client.users.get(email=email)
-            orcid = user.get('orcid') or user.get('unique_id')
-            if not orcid:
-                raise ValueError(f"could not resolve ORCID for email: {email}")
+        if email and not orcid:
+            return self._request('delete', f'/projects/{project_id}/users/me',
+                                 params={'email': email})
         return self._request('delete', f'/projects/{project_id}/users/{orcid}')
 
     def add_user(self, orcid: Optional[str] = None, project_id: str = None,


### PR DESCRIPTION
## Summary

- `projects.remove_user()` now passes `?email=` directly to `DELETE /projects/{id}/users/me` when email is provided, matching the pattern used by `add_user`
- Drops the previous client-side ORCID resolution via `users.get(email=...)`, which required an extra API call