### PR TITLE
Add parallel GCS multipart upload via credential vending

### DIFF
--- a/crucible/cli/config.py
+++ b/crucible/cli/config.py
@@ -140,7 +140,9 @@ Priority order (highest to lowest):
         choices=['api_key', 'api_url', 'graph_explorer_url', 'current_project',
                  'cache_dir',
                  'editor', 'sample_group_by', 'dataset_group_by',
-                 'connect_timeout', 'read_timeout', 'default_limit'],
+                 'include_metadata', 'include_links',
+                 'connect_timeout', 'read_timeout', 'default_limit',
+                 'upload_chunk_size_mb', 'upload_max_workers'],
         help='Configuration key to retrieve'
     )
     get_parser.set_defaults(func=cmd_get)
@@ -155,7 +157,9 @@ Priority order (highest to lowest):
         choices=['api_key', 'api_url', 'graph_explorer_url', 'current_project',
                  'cache_dir',
                  'editor', 'sample_group_by', 'dataset_group_by',
-                 'connect_timeout', 'read_timeout', 'default_limit'],
+                 'include_metadata', 'include_links',
+                 'connect_timeout', 'read_timeout', 'default_limit',
+                 'upload_chunk_size_mb', 'upload_max_workers'],
         help='Configuration key to set'
     )
     set_parser.add_argument(

--- a/crucible/config/config.py
+++ b/crucible/config/config.py
@@ -47,6 +47,9 @@ class Config:
         'connect_timeout':    {'env': 'CRUCIBLE_CONNECT_TIMEOUT',    'ini': 'connect_timeout',    'section': 'network'},
         'read_timeout':       {'env': 'CRUCIBLE_READ_TIMEOUT',       'ini': 'read_timeout',       'section': 'network'},
         'default_limit':      {'env': 'CRUCIBLE_DEFAULT_LIMIT',      'ini': 'default_limit',      'section': 'network'},
+        # [upload] – multipart upload tuning
+        'upload_chunk_size_mb': {'env': 'CRUCIBLE_UPLOAD_CHUNK_SIZE_MB', 'ini': 'chunk_size_mb', 'section': 'upload'},
+        'upload_max_workers':   {'env': 'CRUCIBLE_UPLOAD_MAX_WORKERS',   'ini': 'max_workers',   'section': 'upload'},
     }
 
     def __init__(self):
@@ -247,6 +250,26 @@ class Config:
             return int(raw)
         except (TypeError, ValueError):
             return 100
+
+    @property
+    def upload_chunk_size_mb(self) -> int:
+        """Multipart upload chunk size in MiB (default 64)."""
+        from ..constants import UPLOAD_CHUNK_SIZE_MB
+        raw = self._data.get('upload_chunk_size_mb')
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return UPLOAD_CHUNK_SIZE_MB
+
+    @property
+    def upload_max_workers(self) -> int:
+        """Concurrent upload threads for multipart upload (default 8)."""
+        from ..constants import UPLOAD_MAX_WORKERS
+        raw = self._data.get('upload_max_workers')
+        try:
+            return int(raw)
+        except (TypeError, ValueError):
+            return UPLOAD_MAX_WORKERS
 
     @property
     def client(self):

--- a/crucible/constants.py
+++ b/crucible/constants.py
@@ -7,6 +7,10 @@ Package-wide constants for the Crucible API client.
 DEFAULT_LIMIT = 100   # default page size for list requests
 API_PAGE_MAX  = 1000  # server hard cap per request
 
+# Multipart upload defaults (tuned via benchmarking — see testing/tune_results.jsonl)
+UPLOAD_CHUNK_SIZE_MB = 64   # GCS XML multipart part size in MiB
+UPLOAD_MAX_WORKERS   = 8    # concurrent upload threads
+
 AVAILABLE_INGESTORS = [
     'ApiUploadIngestor',
     'AFMIngestor',

--- a/crucible/resources/files.py
+++ b/crucible/resources/files.py
@@ -31,7 +31,8 @@ class FileOperations(BaseResource):
 
     def add_file_to_dataset(self, dsid: str, file_path: str,
                             ingestion_class: Optional[str] = None,
-                            wait_for_ingestion_response: bool = False) -> Dict:
+                            wait_for_ingestion_response: bool = False,
+                            multipart: bool = True) -> Dict:
         """Upload a file to a dataset and request ingestion.
 
         Args:
@@ -40,6 +41,8 @@ class FileOperations(BaseResource):
             ingestion_class: Ingestion class for the worker (e.g. 'lammps', 'nexus').
                 Defaults to the server-side default if omitted.
             wait_for_ingestion_response: Block until ingestion completes.
+            multipart: Use parallel multipart upload (default: True). Set to False to
+                use the sequential resumable upload (slower but simpler).
 
         Returns:
             Dict: {'associated_file': AssociatedFileRead, 'ingestion_request': IngestionRequest}
@@ -50,7 +53,7 @@ class FileOperations(BaseResource):
         filename = os.path.basename(file_path)
         
         # run file upload
-        file_record = self._upload_file_gcs(dsid, file_path)
+        file_record = self._upload_file_gcs(dsid, file_path, multipart=multipart)
         
         # Trigger ingestion — use the stored filename from the response (full GCS path)
         stored_filename = file_record.get('filename', filename)
@@ -73,24 +76,21 @@ class FileOperations(BaseResource):
         return {'associated_file': file_record, 'ingestion_request': ingestion_request}
 
 
-    def _upload_file_gcs(self, dsid: str, file_path: str) -> Dict:
-        """Upload a file to a dataset, using parallel multipart if google-cloud-storage
-        is installed, otherwise falling back to the sequential resumable upload.
+    def _upload_file_gcs(self, dsid: str, file_path: str, multipart: bool = True) -> Dict:
+        """Upload a file to a dataset.
 
         Args:
             dsid: Dataset unique identifier
             file_path: Local path to the file
+            multipart: If True (default), use parallel multipart upload via the GCS SDK.
+                       If False, use the sequential resumable upload.
 
         Returns:
             Dict: AssociatedFile record for the uploaded file.
         """
-        try:
-            import google.cloud.storage  # noqa: F401
+        if multipart:
             return self._upload_file_gcs_multipart(dsid, file_path)
-        except ImportError:
-            logger.debug("google-cloud-storage not installed, using sequential resumable upload. "
-                         "Install with: pip install nano-crucible[gcs]")
-            return self._upload_file_gcs_resumable(dsid, file_path)
+        return self._upload_file_gcs_resumable(dsid, file_path)
 
     def _upload_file_gcs_multipart(self, dsid: str, file_path: str) -> Dict:
         """Upload using the GCS SDK's parallel multipart upload (upload_chunks_concurrently).

--- a/crucible/resources/files.py
+++ b/crucible/resources/files.py
@@ -74,9 +74,94 @@ class FileOperations(BaseResource):
 
 
     def _upload_file_gcs(self, dsid: str, file_path: str) -> Dict:
-        """Upload a file to a dataset using resumable GCS chunked upload.
-        
-        Automatically resumes interrupted uploads.
+        """Upload a file to a dataset, using parallel multipart if google-cloud-storage
+        is installed, otherwise falling back to the sequential resumable upload.
+
+        Args:
+            dsid: Dataset unique identifier
+            file_path: Local path to the file
+
+        Returns:
+            Dict: AssociatedFile record for the uploaded file.
+        """
+        try:
+            import google.cloud.storage  # noqa: F401
+            return self._upload_file_gcs_multipart(dsid, file_path)
+        except ImportError:
+            logger.debug("google-cloud-storage not installed, using sequential resumable upload. "
+                         "Install with: pip install nano-crucible[gcs]")
+            return self._upload_file_gcs_resumable(dsid, file_path)
+
+    def _upload_file_gcs_multipart(self, dsid: str, file_path: str) -> Dict:
+        """Upload using the GCS SDK's parallel multipart upload (upload_chunks_concurrently).
+
+        Requires google-cloud-storage>=2.7.0 (pip install nano-crucible[gcs]).
+        The API vends a short-lived OAuth2 token so no GCS credentials are needed.
+
+        Args:
+            dsid: Dataset unique identifier
+            file_path: Local path to the file
+
+        Returns:
+            Dict: AssociatedFile record for the uploaded file.
+        """
+        import hashlib
+        from google.cloud import storage
+        from google.cloud.storage import transfer_manager
+        from google.oauth2.credentials import Credentials
+
+        _CHUNK = 32 * 1024 * 1024   # 32 MiB parts
+        _WORKERS = 8
+
+        file_size = os.path.getsize(file_path)
+        filename  = os.path.basename(file_path)
+
+        logger.info(f"Uploading {filename} ({file_size / 1024**2:.1f} MB) "
+                    f"to dataset {dsid} [parallel, {_WORKERS} workers]")
+
+        # SHA256 pre-pass: used for server-side dedup at initiate and sent to /complete.
+        h = hashlib.sha256()
+        with open(file_path, 'rb') as f:
+            for block in iter(lambda: f.read(_CHUNK), b''):
+                h.update(block)
+        sha256_hash = h.hexdigest()
+
+        # Initiate: get upload token (or dedup hit)
+        init = self._request('post', f'/datasets/{dsid}/upload/initiate/multipart',
+                             json={'filename': filename, 'size': file_size,
+                                   'sha256_hash': sha256_hash})
+
+        if init.get('existing_file') is not None:
+            logger.info(f"{filename} already exists in dataset {dsid}, skipping upload")
+            return init['existing_file']
+
+        upload_id = init['upload_id']
+
+        # Build GCS client from vended token — no user credentials needed
+        gcs = storage.Client(
+            credentials=Credentials(token=init['access_token']),
+            project=init['project'],
+        )
+        blob = gcs.bucket(init['bucket']).blob(f"{init['object_prefix']}{filename}")
+
+        logger.debug(f"Starting parallel upload: upload_id={upload_id}, "
+                     f"chunk={_CHUNK >> 20} MiB, workers={_WORKERS}")
+
+        transfer_manager.upload_chunks_concurrently(
+            file_path,
+            blob,
+            chunk_size=_CHUNK,
+            max_workers=_WORKERS,
+            worker_type=transfer_manager.THREAD,
+            checksum="crc32c",
+        )
+
+        logger.info(f"Completing upload for {filename} (upload_id={upload_id})")
+        return self._request('post', f'/datasets/{dsid}/upload/complete',
+                             json={'upload_id': upload_id, 'sha256_hash': sha256_hash})
+
+    def _upload_file_gcs_resumable(self, dsid: str, file_path: str) -> Dict:
+        """Upload using a GCS resumable session URI (sequential, no extra dependencies).
 
         Args:
             dsid: Dataset unique identifier

--- a/crucible/resources/files.py
+++ b/crucible/resources/files.py
@@ -32,7 +32,9 @@ class FileOperations(BaseResource):
     def add_file_to_dataset(self, dsid: str, file_path: str,
                             ingestion_class: Optional[str] = None,
                             wait_for_ingestion_response: bool = False,
-                            multipart: bool = True) -> Dict:
+                            multipart: bool = True,
+                            chunk_size_mb: Optional[int] = None,
+                            max_workers: Optional[int] = None) -> Dict:
         """Upload a file to a dataset and request ingestion.
 
         Args:
@@ -55,7 +57,9 @@ class FileOperations(BaseResource):
         filename = os.path.basename(file_path)
         
         # run file upload
-        file_record, was_existing = self._upload_file_gcs(dsid, file_path, multipart=multipart)
+        file_record, was_existing = self._upload_file_gcs(dsid, file_path, multipart=multipart,
+                                                          chunk_size_mb=chunk_size_mb,
+                                                          max_workers=max_workers)
 
 
         stored_filename = file_record.get('filename', filename)
@@ -89,7 +93,9 @@ class FileOperations(BaseResource):
         items = resp.get('items', []) if isinstance(resp, dict) else (resp or [])
         return any(r.get('status') == 'complete' for r in items)
 
-    def _upload_file_gcs(self, dsid: str, file_path: str, multipart: bool = True) -> Tuple[Dict, bool]:
+    def _upload_file_gcs(self, dsid: str, file_path: str, multipart: bool = True,
+                         chunk_size_mb: Optional[int] = None,
+                         max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
         """Upload a file to a dataset.
 
         Args:
@@ -97,16 +103,22 @@ class FileOperations(BaseResource):
             file_path: Local path to the file
             multipart: If True (default), use parallel multipart upload via the GCS SDK.
                        If False, use the sequential resumable upload.
+            chunk_size_mb: Override chunk size in MiB (uses config/default if None).
+            max_workers: Override number of upload threads (uses config/default if None).
 
         Returns:
             Tuple[Dict, bool]: (AssociatedFile record, was_existing).
                 was_existing is True when the file was a dedup hit and the upload was skipped.
         """
         if multipart:
-            return self._upload_file_gcs_multipart(dsid, file_path)
+            return self._upload_file_gcs_multipart(dsid, file_path,
+                                                    chunk_size_mb=chunk_size_mb,
+                                                    max_workers=max_workers)
         return self._upload_file_gcs_resumable(dsid, file_path)
 
-    def _upload_file_gcs_multipart(self, dsid: str, file_path: str) -> Dict:
+    def _upload_file_gcs_multipart(self, dsid: str, file_path: str,
+                                    chunk_size_mb: Optional[int] = None,
+                                    max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
         """Upload using the GCS SDK's parallel multipart upload (upload_chunks_concurrently).
 
         Requires google-cloud-storage>=2.7.0 (pip install nano-crucible[gcs]).
@@ -126,8 +138,9 @@ class FileOperations(BaseResource):
         from google.cloud.storage import transfer_manager
         from google.oauth2.credentials import Credentials
 
-        _CHUNK   = 32 * 1024 * 1024   # 32 MiB parts
-        _WORKERS = 8
+        cfg      = self._client._config
+        _CHUNK   = (chunk_size_mb or cfg.upload_chunk_size_mb) * 1024 * 1024
+        _WORKERS = max_workers or cfg.upload_max_workers
 
         file_size = os.path.getsize(file_path)
         filename  = os.path.basename(file_path)

--- a/crucible/resources/files.py
+++ b/crucible/resources/files.py
@@ -106,11 +106,13 @@ class FileOperations(BaseResource):
             Dict: AssociatedFile record for the uploaded file.
         """
         import hashlib
+        import base64
+        import google_crc32c
         from google.cloud import storage
         from google.cloud.storage import transfer_manager
         from google.oauth2.credentials import Credentials
 
-        _CHUNK = 32 * 1024 * 1024   # 32 MiB parts
+        _CHUNK   = 32 * 1024 * 1024   # 32 MiB parts
         _WORKERS = 8
 
         file_size = os.path.getsize(file_path)
@@ -119,12 +121,16 @@ class FileOperations(BaseResource):
         logger.info(f"Uploading {filename} ({file_size / 1024**2:.1f} MB) "
                     f"to dataset {dsid} [parallel, {_WORKERS} workers]")
 
-        # SHA256 pre-pass: used for server-side dedup at initiate and sent to /complete.
-        h = hashlib.sha256()
+        # Single pre-pass: SHA256 for Crucible dedup/verify + CRC32C for
+        # post-upload integrity check against the GCS-assembled object.
+        sha = hashlib.sha256()
+        crc = google_crc32c.Checksum()
         with open(file_path, 'rb') as f:
             for block in iter(lambda: f.read(_CHUNK), b''):
-                h.update(block)
-        sha256_hash = h.hexdigest()
+                sha.update(block)
+                crc.update(block)
+        sha256_hash      = sha.hexdigest()
+        local_crc32c_b64 = base64.b64encode(crc.digest()).decode()
 
         # Initiate: get upload token (or dedup hit)
         init = self._request('post', f'/datasets/{dsid}/upload/initiate/multipart',
@@ -147,14 +153,28 @@ class FileOperations(BaseResource):
         logger.debug(f"Starting parallel upload: upload_id={upload_id}, "
                      f"chunk={_CHUNK >> 20} MiB, workers={_WORKERS}")
 
+        # No per-chunk checksum flag — the SDK has a known bug where it sends
+        # the CRC32C in a way GCS rejects. We verify the final assembled object
+        # below instead, which is a stronger guarantee.
         transfer_manager.upload_chunks_concurrently(
             file_path,
             blob,
             chunk_size=_CHUNK,
             max_workers=_WORKERS,
             worker_type=transfer_manager.THREAD,
-            checksum="crc32c",
         )
+
+        # Verify the assembled GCS object's CRC32C matches our local hash.
+        # GCS computes CRC32C over the full assembled byte stream, identical
+        # to a local sequential hash, so this catches any corruption in
+        # upload or server-side assembly.
+        blob.reload()
+        if blob.crc32c and blob.crc32c != local_crc32c_b64:
+            raise RuntimeError(
+                f"CRC32C mismatch for {filename} after assembly: "
+                f"local={local_crc32c_b64} gcs={blob.crc32c}"
+            )
+        logger.debug(f"CRC32C verified: {local_crc32c_b64}")
 
         logger.info(f"Completing upload for {filename} (upload_id={upload_id})")
         return self._request('post', f'/datasets/{dsid}/upload/complete',

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -44,14 +44,13 @@ dependencies = [
     "mfid>=1.0.0",
     "pyyaml>=6.0",
     "google-crc32c>=1.1.0",
+    "google-cloud-storage>=2.7.0",
+    "prompt_toolkit>=3.0",
 ]
 
 [project.optional-dependencies]
 parsers = [
     "ase>=3.22.0",
-]
-shell = [
-    "prompt_toolkit>=3.0",
 ]
 dev = [
     "pytest>=6.0",
@@ -63,14 +62,6 @@ docs = [
     "mkdocs>=1.5",
     "mkdocs-material>=9.0",
     "mkdocstrings[python]>=0.24",
-]
-gcs = [
-    "google-cloud-storage>=2.7.0",
-]
-all = [
-    "ase>=3.22.0",
-    "prompt_toolkit>=3.0",
-    "google-cloud-storage>=2.7.0",
 ]
 
 [project.scripts]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -64,9 +64,13 @@ docs = [
     "mkdocs-material>=9.0",
     "mkdocstrings[python]>=0.24",
 ]
+gcs = [
+    "google-cloud-storage>=2.7.0",
+]
 all = [
     "ase>=3.22.0",
     "prompt_toolkit>=3.0",
+    "google-cloud-storage>=2.7.0",
 ]
 
 [project.scripts]


### PR DESCRIPTION
## Summary

- `_upload_file_gcs_multipart()`: parallel upload using `transfer_manager.upload_chunks_concurrently()` (8 THREAD workers) via a short-lived GCS OAuth2 token vended by `POST /datasets/{dsid}/upload/initiate/multipart`
- `_upload_file_gcs()`: dispatches to multipart (default) or sequential resumable via `multipart=True/False` flag on `add_file_to_dataset()`
- CRC32C computed alongside SHA256 in a single pre-pass; verified against GCS-assembled object via `blob.reload()` post-upload (stronger than per-chunk checksums)
- `google-cloud-storage>=2.7.0` and `prompt_toolkit>=3.0` moved to core dependencies; `[gcs]`, `[shell]`, `[all]` extras removed

## Requires

API endpoint `POST /datasets/{dsid}/upload/initiate/multipart` (feat/gcs-credential-vending on crucible-api).