### PR TITLE
Add user search, upload config tuning, config fixes

### DIFF
--- a/crucible/cli/config.py
+++ b/crucible/cli/config.py
@@ -298,6 +298,11 @@ def cmd_show(args):
     _p("read_timeout",         config.read_timeout)
     _p("default_limit",        config.default_limit)
 
+    # [upload] — multipart upload tuning
+    term.subheader("[upload]  multipart upload")
+    _p("upload_chunk_size_mb", config.upload_chunk_size_mb)
+    _p("upload_max_workers",   config.upload_max_workers)
+
     from crucible.config.config import Config
     env_overrides = {
         mapping['env']: os.environ.get(mapping['env'])

--- a/crucible/cli/user.py
+++ b/crucible/cli/user.py
@@ -39,6 +39,7 @@ def register_subcommand(subparsers):
 
     # Register individual user commands
     _register_get(user_subparsers)
+    _register_search(user_subparsers)
     _register_create(user_subparsers)
     _register_update(user_subparsers)
     _register_list(user_subparsers)
@@ -73,6 +74,51 @@ Examples:
     parser.add_argument('--json', action='store_true', default=False, help='Output as JSON')
 
     parser.set_defaults(func=_execute_get)
+
+
+def _register_search(subparsers):
+    parser = subparsers.add_parser(
+        'search',
+        help='Search for users by name or username',
+        description='Search users by name or username. Available to all authenticated users — '
+                    'no admin required. Returns up to 50 results.',
+        formatter_class=term.ColorHelpFormatter,
+        epilog="""
+Examples:
+    crucible user search fabrice
+    crucible user search ron
+""",
+    )
+    parser.add_argument('query', metavar='TERM', help='Search term')
+    parser.set_defaults(func=_execute_search)
+
+
+def _execute_search(args):
+    """Execute 'user search'."""
+    from crucible.client import CrucibleClient
+    try:
+        users = CrucibleClient().users.search(args.query)
+
+        term.header(f"Users matching '{args.query}' ({len(users)})")
+        if not users:
+            print(f"  {term.dim('No users found.')}")
+            return
+
+        rows = []
+        for u in users:
+            username = u.get('username') or '-'
+            name_parts = [u.get('first_name') or '', u.get('last_name') or '']
+            name  = ' '.join(p for p in name_parts if p) or '-'
+            orcid = term.orcid_link(u.get('orcid') or u.get('unique_id')) or '-'
+            rows.append((username, name, orcid))
+        term.table(rows, ['Username', 'Name', 'ORCID'], max_widths=[20, 25, 19])
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, 'debug', False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
 
 
 def _register_create(subparsers):

--- a/crucible/config/config.py
+++ b/crucible/config/config.py
@@ -499,6 +499,14 @@ def create_config_file(api_key, api_url=None, cache_dir=None,
         else:
             f.write("# default_limit = 100\n")
 
+        # ── [upload] ─────────────────────────────────────────────────────────
+        f.write("\n[upload]\n")
+        f.write("# Multipart upload chunk size in MiB (benchmarked optimum: 64)\n")
+        f.write("# chunk_size_mb = 64\n")
+        f.write("\n")
+        f.write("# Concurrent upload threads (benchmarked optimum: 8)\n")
+        f.write("# max_workers = 8\n")
+
     logger.info(f"Created config file: {config_file}")
 
     # Reload the global config

--- a/crucible/resources/users.py
+++ b/crucible/resources/users.py
@@ -59,6 +59,23 @@ class UserOperations(BaseResource):
         else:
             raise ValueError('provide orcid, username, or email')
 
+    def search(self, q: str) -> List[Dict]:
+        """Search for users by name or username. Available to all authenticated users.
+
+        Matches the query term against username, first name, and last name
+        simultaneously (case-insensitive). Returns UserPublicRead — no email
+        exposed. Hard-capped at 50 results.
+
+        Use client.users.list() for admin-level field-specific filtering.
+
+        Args:
+            q: Search term (e.g. "fabrice", "ron")
+
+        Returns:
+            List[Dict]: Matching users (username, first_name, last_name, orcid)
+        """
+        return self._request('get', '/users/search', params={'q': q})
+
     @_deprecated("client.account.profile()")
     def me(self) -> Dict:
         """Deprecated: use client.account.profile() instead."""


### PR DESCRIPTION
## Summary

- `users.search(q)` → `GET /users/search` — non-admin user lookup by name/username
- `crucible user search TERM` — CLI command, no admin required
- `[upload]` config section: `chunk_size_mb` (default 64) and `max_workers` (default 8), configurable via `crucible config set` or env vars
- `crucible config show` now displays upload settings
- `crucible config get/set` choices: add `upload_chunk_size_mb`, `upload_max_workers`, `include_metadata`, `include_links`