### PR TITLE
v3.0.0 — Major refactor: resource separation, GCS subpackage, ingestion resource

### DIFF
--- a/crucible/__init__.py
+++ b/crucible/__init__.py
@@ -6,7 +6,7 @@ nano-crucible: National Archive for NSRC Observations - Crucible
 Python client library for the Crucible API - the Molecular Foundry data lakehouse.
 """
 
-__version__ = "2.1.2"
+__version__ = "3.0.0"
 __author__ = "mkywall","roncofaber"
 
 import logging

--- a/crucible/cli/__init__.py
+++ b/crucible/cli/__init__.py
@@ -170,7 +170,7 @@ Examples:
 
     # Import subcommands
     from . import (
-        dataset, sample, project, instrument, user, file as file_cmd,  # Resource commands
+        dataset, sample, project, instrument, user, file as file_cmd, ingestion,  # Resource commands
         upload, completion, config as config_cmd, open as open_cmd, link, unlink, whoami, account, cache, download, get, edit, status, deletion, tree, cast, qr  # Utility commands
     )
 
@@ -181,6 +181,7 @@ Examples:
     instrument.register_subcommand(subparsers)
     user.register_subcommand(subparsers)
     file_cmd.register_subcommand(subparsers)
+    ingestion.register_subcommand(subparsers)
 
     # Register utility commands (backward compatibility)
     upload.register_subcommand(subparsers)

--- a/crucible/cli/dataset.py
+++ b/crucible/cli/dataset.py
@@ -1229,7 +1229,7 @@ def _execute_add_file(args):
         rows = []
         for fpath in files:
             print(f"  Uploading {fpath.name} ...", flush=True)
-            client.datasets.add_file_to_dataset(dsid, str(fpath),
+            client.datasets.add_file(dsid, str(fpath),
                                                 ingestion_class=ingestor,
                                                 wait_for_ingestion_response=wait)
             rows.append((fpath.name, term.fmt_size(fpath.stat().st_size), '✓'))
@@ -1322,7 +1322,7 @@ def _execute_ingestion(args):
     from crucible.client import CrucibleClient
     try:
         client = CrucibleClient()
-        reqs = client.datasets.get_ingestion_requests(dsid=args.dataset_id)
+        reqs = client.ingestions.list(dsid=args.dataset_id)
 
         term.header(f"Ingestion Requests · {args.dataset_id} ({len(reqs)})")
         if not reqs:

--- a/crucible/cli/dataset.py
+++ b/crucible/cli/dataset.py
@@ -246,6 +246,7 @@ def register_subcommand(subparsers):
     _register_list_files(dataset_subparsers)
     _register_ingestion(dataset_subparsers)
     _register_search(dataset_subparsers)
+    _register_search_metadata(dataset_subparsers)
     _register_add_keyword(dataset_subparsers)
     _register_list_keywords(dataset_subparsers)
     _register_list_access_groups(dataset_subparsers)
@@ -1351,66 +1352,101 @@ def _execute_ingestion(args):
 
 
 def _register_search(subparsers):
-    """Register the 'dataset search' subcommand."""
     parser = subparsers.add_parser(
         'search',
-        help='Search datasets by scientific metadata',
-        description='Full-text search across scientific metadata of all datasets',
+        help='Fuzzy search datasets by name',
+        description='Fuzzy name search across datasets you can read. '
+                    'For scientific metadata search use search-metadata.',
         formatter_class=term.ColorHelpFormatter,
         epilog="""
 Examples:
-    crucible dataset search "thermal conductivity"
-    crucible dataset search "silicon XRD 300K"
-    crucible dataset search temperature -v
-"""
+    crucible dataset search perovskite
+    crucible dataset search "silicon wafer" --project my-project
+    crucible dataset search XRD --limit 10
+""",
     )
-
-    parser.add_argument(
-        'query',
-        metavar='QUERY',
-        help='Search query string'
-    )
-
-    parser.add_argument(
-        '--limit', '-l',
-        type=int,
-        default=_config.default_limit,
-        metavar='N',
-        help='Maximum number of results to return (default: 100)'
-    )
-
+    parser.add_argument('query', metavar='QUERY', help='Search term (min 3 chars)')
+    parser.add_argument('--project', '-pid', dest='project_id', default=None, metavar='ID',
+                        help='Scope to a specific project')
+    parser.add_argument('--limit', '-l', type=int, default=20, metavar='N',
+                        help='Maximum results (default: 20, max: 50)')
     parser.set_defaults(func=_execute_search)
 
 
 def _execute_search(args):
-    """Execute the 'dataset search' subcommand."""
+    if len(args.query) < 3:
+        logger.error("Search term must be at least 3 characters")
+        sys.exit(1)
     from crucible.client import CrucibleClient
     try:
-        client = CrucibleClient()
-        results = client.datasets.search_scientific_metadata(args.query)
-
-        if args.limit:
-            results = results[:args.limit]
-
-        term.header(f"Search: {args.query} ({len(results)})")
+        client     = CrucibleClient()
+        project_id = args.project_id or _config.current_project or None
+        results    = client.datasets.search(args.query, project_id=project_id,
+                                            limit=args.limit)
+        term.header(f"Datasets matching '{args.query}' ({len(results)})")
         if not results:
             print(f"  {term.dim('No results found.')}")
-        else:
-            for r in results:
-                mfid = r.get('dataset_mfid', '-')
-                print(f"  {term.cyan(mfid)}")
-                if args.verbose:
-                    scimd = r.get('scientific_metadata', {})
-                    for key, value in scimd.items():
-                        if isinstance(value, dict):
-                            print(f"    {term.dim(key + ':')} <dict, {len(value)} keys>")
-                        elif isinstance(value, list):
-                            print(f"    {term.dim(key + ':')} <list, {len(value)} items>")
-                        else:
-                            print(f"    {term.dim(key + ':')} {value}")
-
+            return
+        from .helpers import explorer_url
+        rows = []
+        for r in results:
+            uid  = r.get('unique_id') or ''
+            pid  = r.get('project_id') or project_id or ''
+            rows.append((
+                r.get('dataset_name') or '(unnamed)',
+                term.mfid_link(uid, explorer_url(uid, pid, 'dataset')),
+                r.get('measurement') or '-',
+            ))
+        term.table(rows, ['Name', 'MFID', 'Measurement'], max_widths=[35, 26, 20])
     except Exception as e:
-        logger.error(f"Error searching datasets: {e}")
+        logger.error(f"Error: {e}")
+        if getattr(args, "debug", False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+def _register_search_metadata(subparsers):
+    for name in ('search-metadata', 'search-md'):
+        parser = subparsers.add_parser(
+            name,
+            help='Search datasets by scientific metadata' if name == 'search-metadata' else None,
+            description='Full-text search across scientific metadata of all accessible datasets.',
+            formatter_class=term.ColorHelpFormatter,
+            epilog="""
+Examples:
+    crucible dataset search-metadata "thermal conductivity"
+    crucible dataset search-md "silicon XRD 300K"
+""",
+        )
+        parser.add_argument('query', metavar='QUERY', help='Search query string')
+        parser.add_argument('--limit', '-l', type=int, default=50, metavar='N',
+                            help='Maximum results (default: 50)')
+        parser.set_defaults(func=_execute_search_metadata)
+
+
+def _execute_search_metadata(args):
+    from crucible.client import CrucibleClient
+    try:
+        client  = CrucibleClient()
+        results = client.datasets.search_metadata(args.query, limit=args.limit)
+        term.header(f"Metadata search: {args.query} ({len(results)})")
+        if not results:
+            print(f"  {term.dim('No results found.')}")
+            return
+        for r in results:
+            mfid  = r.get('unique_id') or r.get('dataset_mfid', '-')
+            print(f"  {term.cyan(mfid)}")
+            scimd = r.get('scientific_metadata') or {}
+            for key, value in scimd.items():
+                if isinstance(value, dict):
+                    print(f"    {term.dim(key + ':')} <dict, {len(value)} keys>")
+                elif isinstance(value, list):
+                    print(f"    {term.dim(key + ':')} <list, {len(value)} items>")
+                else:
+                    print(f"    {term.dim(key + ':')} {value}")
+    except Exception as e:
+        logger.error(f"Error: {e}")
         if getattr(args, "debug", False):
             import traceback
             traceback.print_exc()
@@ -1483,7 +1519,7 @@ def _execute_list_keywords(args):
         for kw in keywords:
             word  = kw.get('keyword', kw) if isinstance(kw, dict) else kw
             count = kw.get('num_datasets') if isinstance(kw, dict) else None
-            suffix = f"  {term.dim(f'({count} datasets)')}" if args.verbose and count is not None else ""
+            suffix = f"  {term.dim(f'({count} datasets)')}" if getattr(args, 'verbose', False) and count is not None else ""
             print(f"  {word}{suffix}")
 
     except Exception as e:
@@ -2020,7 +2056,7 @@ def _execute_parsers(args):
     builtin_names = set(PARSER_REGISTRY.keys())
 
     term.header(f"Dataset Parsers ({len(all_parsers)})")
-    if args.verbose:
+    if getattr(args, 'verbose', False):
         rows = [
             (
                 name,

--- a/crucible/cli/file.py
+++ b/crucible/cli/file.py
@@ -234,7 +234,7 @@ def _execute_ingestion(args):
     from crucible.client import CrucibleClient
     try:
         client = CrucibleClient()
-        reqs = client.datasets.get_ingestion_requests(file_id=args.file_id)
+        reqs = client.ingestions.list(file_id=args.file_id)
 
         term.header(f"Ingestion Requests · {args.file_id} ({len(reqs)})")
         if not reqs:

--- a/crucible/cli/file.py
+++ b/crucible/cli/file.py
@@ -79,9 +79,9 @@ def _execute_list(args):
         client = CrucibleClient()
         dsid = getattr(args, 'dataset', None)
         if dsid:
-            files = client.datasets.list_files(dsid=dsid)
+            files = client.datasets.get_associated_files(dsid)
         else:
-            files = client.datasets.list_files(limit=args.limit, sha256_hash=args.sha256)
+            files = client.files.list(limit=args.limit, sha256_hash=args.sha256)
 
         sha256_filter = getattr(args, 'sha256', None)
         if sha256_filter and dsid:
@@ -133,7 +133,7 @@ def _execute_get(args):
     from crucible.client import CrucibleClient
     try:
         client = CrucibleClient()
-        f = client.datasets.get_file(args.file_id)
+        f = client.files.get(args.file_id)
 
         _p = term.field_printer(12)
         term.header("File")
@@ -192,7 +192,7 @@ def _execute_download(args):
     try:
         client = CrucibleClient()
 
-        f    = client.datasets.get_file(args.file_id)
+        f    = client.files.get(args.file_id)
         name = _bare_name(f)
 
         if not f.get('storage_path'):

--- a/crucible/cli/file.py
+++ b/crucible/cli/file.py
@@ -79,7 +79,7 @@ def _execute_list(args):
         client = CrucibleClient()
         dsid = getattr(args, 'dataset', None)
         if dsid:
-            files = client.datasets.get_associated_files(dsid)
+            files = client.datasets.list_files(dsid)
         else:
             files = client.files.list(limit=args.limit, sha256_hash=args.sha256)
 
@@ -146,7 +146,7 @@ def _execute_get(args):
         if f.get('storage_path'):
             _p("Status", term.green("Ingested"))
             try:
-                url = client.datasets.get_download_link(args.file_id)
+                url = client.files.get_download_link(args.file_id)
                 _p("Download", term.hyperlink(term.cyan("link"), url))
             except Exception:
                 _p("Download", term.dim("unavailable"))
@@ -186,44 +186,21 @@ Examples:
 
 def _execute_download(args):
     """Execute 'crucible file download'."""
-    import tempfile
     import requests as _requests
     from crucible.client import CrucibleClient
     try:
         client = CrucibleClient()
-
-        f    = client.files.get(args.file_id)
-        name = _bare_name(f)
-
-        if not f.get('storage_path'):
-            logger.error(f"{name} has not been ingested yet - cannot download")
-            sys.exit(1)
-
         try:
-            url = client.datasets.get_download_link(args.file_id)
+            output_path = client.files.download(args.file_id, output_dir=args.output_dir)
+        except RuntimeError as e:
+            logger.error(str(e))
+            sys.exit(1)
         except _requests.exceptions.HTTPError as e:
             if e.response is not None and e.response.status_code == 404:
-                logger.error(f"{name} is not yet available for download")
+                logger.error(f"File {args.file_id} is not yet available for download")
             else:
-                logger.error(f"Failed to get download link: {e}")
+                logger.error(f"Failed to download: {e}")
             sys.exit(1)
-
-        output_path = os.path.join(args.output_dir, name)
-        os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
-
-        logger.info(f"Downloading {name}...")
-        response = client._session.get(url, stream=True)
-        response.raise_for_status()
-
-        tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(output_path)))
-        try:
-            with os.fdopen(tmp_fd, 'wb') as out:
-                for chunk in response.iter_content(chunk_size=1024 * 1024):
-                    out.write(chunk)
-            os.replace(tmp_path, output_path)
-        except Exception:
-            os.unlink(tmp_path)
-            raise
 
         print(f"  {term.green('✓')} {output_path}")
 

--- a/crucible/cli/helpers.py
+++ b/crucible/cli/helpers.py
@@ -188,7 +188,7 @@ def cache_resource(shell_state, client, data, rtype, resource_id, **flags):
         pool = ThreadPoolExecutor(max_workers=3, thread_name_prefix='prefetch')
         futures = {
             '_keywords_future': pool.submit(client.datasets.get_keywords, resource_id),
-            '_files_future':    pool.submit(client.datasets.get_associated_files, resource_id),
+            '_files_future':    pool.submit(client.datasets.list_files, resource_id),
             '_dl_links_future': pool.submit(client.datasets.get_download_links, resource_id),
         }
         if not data.get('links'):

--- a/crucible/cli/helpers.py
+++ b/crucible/cli/helpers.py
@@ -188,7 +188,7 @@ def cache_resource(shell_state, client, data, rtype, resource_id, **flags):
         pool = ThreadPoolExecutor(max_workers=3, thread_name_prefix='prefetch')
         futures = {
             '_keywords_future': pool.submit(client.datasets.get_keywords, resource_id),
-            '_files_future':    pool.submit(client.datasets.list_files, resource_id),
+            '_files_future':    pool.submit(client.datasets.get_associated_files, resource_id),
             '_dl_links_future': pool.submit(client.datasets.get_download_links, resource_id),
         }
         if not data.get('links'):

--- a/crucible/cli/ingestion.py
+++ b/crucible/cli/ingestion.py
@@ -1,0 +1,168 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Ingestion subcommand — manage ingestion requests.
+"""
+
+import sys
+import logging
+
+logger = logging.getLogger(__name__)
+
+from . import term
+
+
+def register_subcommand(subparsers):
+    parser = subparsers.add_parser(
+        'ingestion',
+        help='Manage ingestion requests',
+        description='List, inspect, and wait on ingestion requests.',
+    )
+    sub = parser.add_subparsers(dest='ingestion_command', metavar='COMMAND')
+    sub.required = True
+
+    _register_list(sub)
+    _register_get(sub)
+    _register_wait(sub)
+
+
+def _register_list(subparsers):
+    parser = subparsers.add_parser(
+        'list',
+        help='List ingestion requests',
+        description='List ingestion requests, optionally scoped to a dataset or file.',
+        formatter_class=term.ColorHelpFormatter,
+        epilog="""
+Examples:
+    crucible ingestion list
+    crucible ingestion list --dataset DSID
+    crucible ingestion list --file FILE_ID
+""",
+    )
+    parser.add_argument('--dataset', '-d', dest='dataset_id', default=None,
+                        metavar='DSID', help='Filter by dataset ID')
+    parser.add_argument('--file', '-f', dest='file_id', default=None,
+                        metavar='FILE_ID', help='Filter by file MFID')
+    parser.add_argument('--limit', '-l', type=int, default=50, metavar='N',
+                        help='Maximum results (default: 50)')
+    parser.set_defaults(func=_execute_list)
+
+
+def _execute_list(args):
+    from crucible.client import CrucibleClient
+    try:
+        client = CrucibleClient()
+        reqs   = client.ingestions.list(dsid=args.dataset_id,
+                                        file_id=args.file_id,
+                                        limit=args.limit)
+
+        scope = args.dataset_id or args.file_id or 'all'
+        term.header(f"Ingestion Requests · {scope} ({len(reqs)})")
+        if not reqs:
+            print(f"  {term.dim('No ingestion requests found.')}")
+            return
+
+        rows = []
+        for r in reqs:
+            status = r.get('status') or '-'
+            color  = (term.green  if status == 'complete' else
+                      term.red    if status == 'failed'   else
+                      term.yellow)
+            rows.append((
+                str(r.get('id', '-')),
+                color(status),
+                r.get('ingestion_class') or '-',
+                r.get('file_id') or '-',
+                term.fmt_ts(r.get('created_at') or r.get('creation_time')) or '-',
+            ))
+        term.table(rows, ['ID', 'Status', 'Class', 'File MFID', 'Created'],
+                   max_widths=[8, 12, 25, 30, 20])
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, 'debug', False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+def _register_get(subparsers):
+    parser = subparsers.add_parser(
+        'get',
+        help='Get a single ingestion request',
+        description='Show details of a single ingestion request by ID.',
+        formatter_class=term.ColorHelpFormatter,
+        epilog="""
+Examples:
+    crucible ingestion get 42
+""",
+    )
+    parser.add_argument('request_id', metavar='REQUEST_ID', type=int,
+                        help='Integer ingestion request ID')
+    parser.set_defaults(func=_execute_get)
+
+
+def _execute_get(args):
+    from crucible.client import CrucibleClient
+    try:
+        client = CrucibleClient()
+        r = client.ingestions.get(args.request_id)
+        _p = term.field_printer(16)
+        status = r.get('status') or '-'
+        color  = (term.green  if status == 'complete' else
+                  term.red    if status == 'failed'   else
+                  term.yellow)
+        term.header(f"Ingestion Request #{r.get('id')}")
+        _p("Status",  color(status))
+        _p("Class",   r.get('ingestion_class') or '-')
+        _p("File",    r.get('file_id') or '-')
+        _p("Dataset", r.get('dataset_id') or '-')
+        _p("Created", term.fmt_ts(r.get('created_at') or r.get('creation_time')))
+        if r.get('time_completed'):
+            _p("Completed", term.fmt_ts(r.get('time_completed')))
+        if r.get('error_message'):
+            _p("Error", term.red(r.get('error_message')))
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, 'debug', False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+def _register_wait(subparsers):
+    parser = subparsers.add_parser(
+        'wait',
+        help='Wait for an ingestion request to complete',
+        description='Poll an ingestion request until it reaches a terminal state.',
+        formatter_class=term.ColorHelpFormatter,
+        epilog="""
+Examples:
+    crucible ingestion wait 42
+""",
+    )
+    parser.add_argument('request_id', metavar='REQUEST_ID', type=int,
+                        help='Integer ingestion request ID')
+    parser.set_defaults(func=_execute_wait)
+
+
+def _execute_wait(args):
+    from crucible.client import CrucibleClient
+    try:
+        client = CrucibleClient()
+        logger.info(f"Waiting for ingestion request {args.request_id}...")
+        r = client.ingestions.wait(args.request_id)
+        status = r.get('status', '-')
+        if status == 'complete':
+            logger.info(f"✓ Ingestion {args.request_id} completed successfully")
+        else:
+            logger.error(f"Ingestion {args.request_id} ended with status: {status}")
+            sys.exit(1)
+
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, 'debug', False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)

--- a/crucible/cli/ingestion.py
+++ b/crucible/cli/ingestion.py
@@ -72,8 +72,8 @@ def _execute_list(args):
                 str(r.get('id', '-')),
                 color(status),
                 r.get('ingestion_class') or '-',
-                r.get('file_id') or '-',
-                term.fmt_ts(r.get('created_at') or r.get('creation_time')) or '-',
+                r.get('file_mfid') or '-',
+                term.fmt_ts(r.get('time_created')) or '-',
             ))
         term.table(rows, ['ID', 'Status', 'Class', 'File MFID', 'Created'],
                    max_widths=[8, 12, 25, 30, 20])
@@ -115,9 +115,9 @@ def _execute_get(args):
         term.header(f"Ingestion Request #{r.get('id')}")
         _p("Status",  color(status))
         _p("Class",   r.get('ingestion_class') or '-')
-        _p("File",    r.get('file_id') or '-')
-        _p("Dataset", r.get('dataset_id') or '-')
-        _p("Created", term.fmt_ts(r.get('created_at') or r.get('creation_time')))
+        _p("File",    r.get('file_mfid') or '-')
+        _p("Dataset", r.get('dataset_mfid') or '-')
+        _p("Created", term.fmt_ts(r.get('time_created')))
         if r.get('time_completed'):
             _p("Completed", term.fmt_ts(r.get('time_completed')))
         if r.get('error_message'):

--- a/crucible/cli/instrument.py
+++ b/crucible/cli/instrument.py
@@ -43,6 +43,8 @@ def register_subcommand(subparsers):
 
     # Register individual instrument commands
     _register_list(instrument_subparsers)
+    _register_search(instrument_subparsers)
+    _register_search_metadata(instrument_subparsers)
     _register_get(instrument_subparsers)
     _register_create(instrument_subparsers)
     _register_update(instrument_subparsers)
@@ -533,3 +535,79 @@ def _execute_edit(args):
         logger.error(f"Error connecting: {e}")
         sys.exit(1)
     _edit_instrument(args.unique_id, client, debug=getattr(args, 'debug', False))
+
+
+def _register_search(subparsers):
+    parser = subparsers.add_parser(
+        'search',
+        help='Fuzzy search instruments by name, type, or manufacturer',
+        description='Fuzzy search across instruments.',
+        formatter_class=term.ColorHelpFormatter,
+        epilog="""
+Examples:
+    crucible instrument search titan
+    crucible instrument search "electron microscope"
+    crucible instrument search XRD --limit 10
+""",
+    )
+    parser.add_argument('query', metavar='QUERY', help='Search term (min 3 chars)')
+    parser.add_argument('--limit', '-l', type=int, default=20, metavar='N',
+                        help='Maximum results (default: 20, max: 50)')
+    parser.set_defaults(func=_execute_search)
+
+
+def _execute_search(args):
+    if len(args.query) < 3:
+        logger.error("Search term must be at least 3 characters")
+        sys.exit(1)
+    from crucible.client import CrucibleClient
+    try:
+        client  = CrucibleClient()
+        results = client.instruments.search(args.query, limit=args.limit)
+        term.header(f"Instruments matching '{args.query}' ({len(results)})")
+        if not results:
+            print(f"  {term.dim('No results found.')}")
+            return
+        rows = [(r.get('instrument_name', '-'), r.get('instrument_type') or '-',
+                 r.get('manufacturer') or '-', r.get('unique_id', '-')) for r in results]
+        term.table(rows, ['Name', 'Type', 'Manufacturer', 'MFID'],
+                   max_widths=[25, 20, 20, 26])
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, "debug", False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+def _register_search_metadata(subparsers):
+    for name in ('search-metadata', 'search-md'):
+        parser = subparsers.add_parser(
+            name,
+            help='Search instruments by scientific metadata' if name == 'search-metadata' else None,
+            description='Full-text search across scientific metadata of all accessible instruments.',
+            formatter_class=term.ColorHelpFormatter,
+        )
+        parser.add_argument('query', metavar='QUERY', help='Search query string')
+        parser.add_argument('--limit', '-l', type=int, default=50, metavar='N',
+                            help='Maximum results (default: 50)')
+        parser.set_defaults(func=_execute_search_metadata)
+
+
+def _execute_search_metadata(args):
+    from crucible.client import CrucibleClient
+    try:
+        client  = CrucibleClient()
+        results = client.instruments.search_metadata(args.query, limit=args.limit)
+        term.header(f"Metadata search: {args.query} ({len(results)})")
+        if not results:
+            print(f"  {term.dim('No results found.')}")
+            return
+        for r in results:
+            print(f"  {term.cyan(r.get('unique_id', '-'))}")
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, "debug", False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)

--- a/crucible/cli/project.py
+++ b/crucible/cli/project.py
@@ -44,6 +44,8 @@ def register_subcommand(subparsers):
 
     # Register individual project commands
     _register_list(project_subparsers)
+    _register_search(project_subparsers)
+    _register_search_metadata(project_subparsers)
     _register_get(project_subparsers)
     _register_create(project_subparsers)
     _register_update(project_subparsers)
@@ -744,3 +746,77 @@ def _execute_edit(args):
         logger.error(f"Error connecting: {e}")
         sys.exit(1)
     _edit_project(args.project_id, client, debug=getattr(args, 'debug', False))
+
+
+def _register_search(subparsers):
+    parser = subparsers.add_parser(
+        'search',
+        help='Fuzzy search projects by name or ID',
+        description='Fuzzy search across projects you are a member of.',
+        formatter_class=term.ColorHelpFormatter,
+        epilog="""
+Examples:
+    crucible project search alphafold
+    crucible project search "10k"
+""",
+    )
+    parser.add_argument('query', metavar='QUERY', help='Search term (min 3 chars)')
+    parser.add_argument('--limit', '-l', type=int, default=20, metavar='N',
+                        help='Maximum results (default: 20, max: 50)')
+    parser.set_defaults(func=_execute_search)
+
+
+def _execute_search(args):
+    if len(args.query) < 3:
+        logger.error("Search term must be at least 3 characters")
+        sys.exit(1)
+    from crucible.client import CrucibleClient
+    try:
+        client  = CrucibleClient()
+        results = client.projects.search(args.query, limit=args.limit)
+        term.header(f"Projects matching '{args.query}' ({len(results)})")
+        if not results:
+            print(f"  {term.dim('No results found.')}")
+            return
+        rows = [(r.get('project_id', '-'), r.get('title') or '-',
+                 r.get('organization') or '-') for r in results]
+        term.table(rows, ['ID', 'Title', 'Organization'], max_widths=[20, 30, 20])
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, "debug", False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+def _register_search_metadata(subparsers):
+    for name in ('search-metadata', 'search-md'):
+        parser = subparsers.add_parser(
+            name,
+            help='Search projects by scientific metadata' if name == 'search-metadata' else None,
+            description='Full-text search across scientific metadata of all accessible projects.',
+            formatter_class=term.ColorHelpFormatter,
+        )
+        parser.add_argument('query', metavar='QUERY', help='Search query string')
+        parser.add_argument('--limit', '-l', type=int, default=50, metavar='N',
+                            help='Maximum results (default: 50)')
+        parser.set_defaults(func=_execute_search_metadata)
+
+
+def _execute_search_metadata(args):
+    from crucible.client import CrucibleClient
+    try:
+        client  = CrucibleClient()
+        results = client.projects.search_metadata(args.query, limit=args.limit)
+        term.header(f"Metadata search: {args.query} ({len(results)})")
+        if not results:
+            print(f"  {term.dim('No results found.')}")
+            return
+        for r in results:
+            print(f"  {term.cyan(r.get('unique_id', '-'))}")
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, "debug", False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)

--- a/crucible/cli/sample.py
+++ b/crucible/cli/sample.py
@@ -45,6 +45,8 @@ def register_subcommand(subparsers):
 
     # Register individual sample commands
     _register_list(sample_subparsers)
+    _register_search(sample_subparsers)
+    _register_search_metadata(sample_subparsers)
     _register_get(sample_subparsers)
     _register_create(sample_subparsers)
     _register_update(sample_subparsers)
@@ -1078,6 +1080,93 @@ def _execute_remove_dataset(args):
         logger.info(f"✓ Unlinked sample {args.sample_id} from dataset {args.dataset}")
     except Exception as e:
         logger.error(f"Error unlinking dataset from sample: {e}")
+        if getattr(args, "debug", False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+def _register_search(subparsers):
+    parser = subparsers.add_parser(
+        'search',
+        help='Fuzzy search samples by name',
+        description='Fuzzy name search across samples you can read. '
+                    'For scientific metadata search use search-metadata.',
+        formatter_class=term.ColorHelpFormatter,
+        epilog="""
+Examples:
+    crucible sample search silicon
+    crucible sample search "wafer" --project my-project
+""",
+    )
+    parser.add_argument('query', metavar='QUERY', help='Search term (min 3 chars)')
+    parser.add_argument('--project', '-pid', dest='project_id', default=None, metavar='ID',
+                        help='Scope to a specific project')
+    parser.add_argument('--limit', '-l', type=int, default=20, metavar='N',
+                        help='Maximum results (default: 20, max: 50)')
+    parser.set_defaults(func=_execute_search)
+
+
+def _execute_search(args):
+    if len(args.query) < 3:
+        logger.error("Search term must be at least 3 characters")
+        sys.exit(1)
+    from crucible.client import CrucibleClient
+    try:
+        client     = CrucibleClient()
+        project_id = args.project_id or _config.current_project or None
+        results    = client.samples.search(args.query, project_id=project_id,
+                                           limit=args.limit)
+        term.header(f"Samples matching '{args.query}' ({len(results)})")
+        if not results:
+            print(f"  {term.dim('No results found.')}")
+            return
+        from .helpers import explorer_url
+        rows = []
+        for r in results:
+            uid = r.get('unique_id') or ''
+            pid = r.get('project_id') or project_id or ''
+            rows.append((
+                r.get('sample_name') or '(unnamed)',
+                term.mfid_link(uid, explorer_url(uid, pid, 'sample')),
+                r.get('sample_type') or '-',
+            ))
+        term.table(rows, ['Name', 'MFID', 'Type'], max_widths=[35, 26, 20])
+    except Exception as e:
+        logger.error(f"Error: {e}")
+        if getattr(args, "debug", False):
+            import traceback
+            traceback.print_exc()
+        sys.exit(1)
+
+
+def _register_search_metadata(subparsers):
+    for name in ('search-metadata', 'search-md'):
+        parser = subparsers.add_parser(
+            name,
+            help='Search samples by scientific metadata' if name == 'search-metadata' else None,
+            description='Full-text search across scientific metadata of all accessible samples.',
+            formatter_class=term.ColorHelpFormatter,
+        )
+        parser.add_argument('query', metavar='QUERY', help='Search query string')
+        parser.add_argument('--limit', '-l', type=int, default=50, metavar='N',
+                            help='Maximum results (default: 50)')
+        parser.set_defaults(func=_execute_search_metadata)
+
+
+def _execute_search_metadata(args):
+    from crucible.client import CrucibleClient
+    try:
+        client  = CrucibleClient()
+        results = client.samples.search_metadata(args.query, limit=args.limit)
+        term.header(f"Metadata search: {args.query} ({len(results)})")
+        if not results:
+            print(f"  {term.dim('No results found.')}")
+            return
+        for r in results:
+            print(f"  {term.cyan(r.get('unique_id') or r.get('sample_mfid', '-'))}")
+    except Exception as e:
+        logger.error(f"Error: {e}")
         if getattr(args, "debug", False):
             import traceback
             traceback.print_exc()

--- a/crucible/cli/user.py
+++ b/crucible/cli/user.py
@@ -95,6 +95,9 @@ Examples:
 
 def _execute_search(args):
     """Execute 'user search'."""
+    if len(args.query) < 3:
+        logger.error("Search term must be at least 3 characters")
+        sys.exit(1)
     from crucible.client import CrucibleClient
     try:
         users = CrucibleClient().users.search(args.query)

--- a/crucible/client.py
+++ b/crucible/client.py
@@ -76,7 +76,7 @@ class CrucibleClient:
         # Initialize resource operations
         from .resources import FileOperations, DatasetOperations, SampleOperations, \
         ProjectOperations, UserOperations, InstrumentOperations, DeletionOperations, \
-        GraphOperations, AccountOperations
+        GraphOperations, AccountOperations, IngestionOperations
 
         self.files = FileOperations(self)
         self.datasets = DatasetOperations(self)
@@ -87,6 +87,7 @@ class CrucibleClient:
         self.deletions = DeletionOperations(self)
         self.graphs = GraphOperations(self)
         self.account = AccountOperations(self)
+        self.ingestions = IngestionOperations(self)
     
     def _request(self, method: str, endpoint: str, **kwargs) -> Any:
         """Make an HTTP request to the API.
@@ -196,22 +197,12 @@ class CrucibleClient:
         return resp.json()
 
     def whoami(self) -> Dict:
-        """Return account info for the current API key.
+        """Return full auth context for the current API key.
 
-        Returns:
-            Dict: user_unique_id, access_group_ids, and user_info with full
-                  user profile fields.
+        Delegates to client.account.whoami(). Kept here for backward compatibility
+        and because it spans the account context rather than a specific resource.
         """
-        result = self._request('get', '/account')
-        # Normalize field renames introduced in API v2 so callers work against
-        # both API versions without separate handling.
-        user_info = result.get('user_info') or {}
-        is_service = user_info.get('is_service_account', False)
-        if not is_service and 'orcid' not in user_info and 'unique_id' in user_info:
-            user_info['orcid'] = user_info['unique_id']
-        if 'user_unique_id' in result and 'access_group_name' not in result:
-            result['access_group_name'] = result['user_unique_id']
-        return result
+        return self.account.whoami()
 
     def get_resource_type(self, resource_id: str) -> str:
         """
@@ -263,18 +254,6 @@ class CrucibleClient:
                                         include_metadata=include_metadata)
         else:
             raise ValueError(f"Unknown or unsupported resource type: {resource_type}")
-
-    def search_scientific_metadata(self, q: str, limit: int = None) -> list:
-        """Full-text search across scientific metadata of all accessible resources.
-
-        Results are ranked by relevance and may include datasets or samples.
-        Each result contains 'unique_id' (the resource MFID) and 'scientific_metadata'.
-
-        Args:
-            q: Plain-text search query (English-language stemmed).
-            limit: Max results to return (default 50, max 200).
-        """
-        return self.datasets.search_scientific_metadata(q, limit=limit)
 
     def get_links(self, resource_id: str) -> list:
         """Return immediate links for any resource (dataset or sample).
@@ -391,356 +370,20 @@ class CrucibleClient:
                 f"Cannot unlink resources: {id_a} is {type_a}, {id_b} is {type_b}."
             )
     
+    @_deprecated("client.datasets.download() or client.samples.download()")
     def download(self, resource_id: str, output_dir: str = 'crucible-downloads',
                  no_files: bool = False, no_record: bool = False,
                  overwrite_existing: bool = True,
                  include: Optional[List[str]] = None,
                  exclude: Optional[List[str]] = None) -> List[str]:
-        """Download a resource record and, for datasets, its files.
-
-        Args:
-            resource_id (str): Sample or dataset unique identifier
-            output_dir (str): Directory to save files (default: 'crucible-downloads')
-            no_files (bool): Skip file download, save record JSON only
-            no_record (bool): Skip saving record.json
-            overwrite_existing (bool): Overwrite existing files (default: True)
-            include (list, optional): Glob patterns — only download matching files
-            exclude (list, optional): Glob patterns — skip matching files
-
-        Returns:
-            List[str]: Paths of all downloaded files (record.json + data files)
-        """
-        import os
-
+        """Deprecated: use client.datasets.download() or client.samples.download() instead."""
         resource_type = self.get_resource_type(resource_id)
         if resource_type == 'dataset':
-            record = self.datasets.get(resource_id, include_metadata=True)
+            return self.datasets.download(resource_id, output_dir=output_dir,
+                                          no_files=no_files, no_record=no_record,
+                                          overwrite_existing=overwrite_existing,
+                                          include=include, exclude=exclude)
         elif resource_type == 'sample':
-            record = self.samples.get(resource_id)
+            return self.samples.download(resource_id, output_dir=output_dir)
         else:
             raise ValueError(f"Cannot download resource of type: {resource_type}")
-
-        try:
-            os.makedirs(output_dir, exist_ok=True)
-        except (OSError, PermissionError) as e:
-            raise OSError(f"Cannot create output directory '{output_dir}'.") from e
-
-        downloaded = []
-
-        if not no_record:
-            record_dir = os.path.join(output_dir, resource_id)
-            os.makedirs(record_dir, exist_ok=True)
-            json_path = os.path.join(record_dir, 'record.json')
-            with open(json_path, 'w') as f:
-                json.dump(record, f, indent=2)
-            logger.info(f"Saved record to {json_path}")
-            downloaded.append(json_path)
-
-        if resource_type == 'dataset' and not no_files:
-            files = self.datasets._fetch_files(resource_id, output_dir=output_dir,
-                                               overwrite_existing=overwrite_existing,
-                                               include=include, exclude=exclude)
-            downloaded.extend(files)
-            if files:
-                logger.info(f"Downloaded {len(files)} file(s) to {output_dir}")
-
-        return downloaded
-
-    #%% PROJECT METHODS (DEPRECATED)
-
-    @_deprecated("client.projects.create()")
-    def create_project(self, project: Union[Project, Dict]) -> Dict:
-        """Backward compatible: Use client.projects.create() instead."""
-        return self.projects.create(project)
-
-    @_deprecated("client.projects.get()")
-    def get_project(self, project_id: str) -> Dict:
-        """Backward compatible: Use client.projects.get() instead."""
-        return self.projects.get(project_id)
-
-    @_deprecated("client.projects.list()")
-    def list_projects(self, orcid: str = None, limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Backward compatible: Use client.projects.list() instead."""
-        return self.projects.list(orcid=orcid, limit=limit)
-
-    @_deprecated("client.projects.get_users()")
-    def get_project_users(self, project_id: str, limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Backward compatible: Use client.projects.get_users() instead."""
-        return self.projects.get_users(project_id, limit=limit)
-
-    @_deprecated("client.projects.add_user()")
-    def add_user_to_project(self, orcid, project_id):
-        """Backward compatible: Use client.projects.add_user() instead."""
-        return self.projects.add_user(orcid, project_id)
-    
-    @_deprecated("client.projects.get_or_create()")
-    def get_or_add_project(self, project_id, get_project_info_function = None, **kwargs):
-        """Backward compatible: Use client.projects.get_or_create() instead."""
-        if get_project_info_function is None:
-            from .resources.projects import _build_project_from_args
-            get_project_info_function = _build_project_from_args
-        return self.projects.get_or_create(project_id, get_project_info_function=get_project_info_function, **kwargs)
-    
-    #%% SAMPLE METHODS (DEPRECATED)
-
-    @_deprecated("client.samples.get()")
-    def get_sample(self, sample_id: str) -> Dict:
-        """Backward compatible: Use client.samples.get() instead."""
-        return self.samples.get(sample_id)
-    
-    @_deprecated("client.samples.list_parents()")
-    def list_parents_of_sample(self, sample_id, limit = DEFAULT_LIMIT, **kwargs)-> List[Dict]:
-        """Backward compatible: Use client.samples.list_parents() instead."""
-        return self.samples.list_parents(sample_id, limit=limit, **kwargs)
-    
-    @_deprecated("client.samples.list_children()")
-    def list_children_of_sample(self, sample_id, limit = DEFAULT_LIMIT, **kwargs)-> List[Dict]:
-        """Backward compatible: Use client.samples.list_children() instead."""
-        return self.samples.list_children(sample_id, limit=limit, **kwargs)
-    
-    @_deprecated("client.samples.list()")
-    def list_samples(self, dataset_id: str = None, parent_id: str = None, limit: int = DEFAULT_LIMIT, **kwargs) -> List[Dict]:
-        """Backward compatible: Use client.samples.list() instead."""
-        return self.samples.list(dataset_id=dataset_id, parent_id=parent_id, limit=limit, **kwargs)
-        
-    @_deprecated("client.samples.update()")
-    def update_sample(self, unique_id: str = None, sample_name: str = None, description: str = None,
-                   creation_date: str = None, owner_orcid: str = None, owner_id: int = None,
-                   project_id: str = None, sample_type: str = None,
-                   parents: List[Dict] = [], children: List[Dict] = []):
-        """Backward compatible: Use client.samples.update() instead."""
-        return self.samples.update(unique_id=unique_id, sample_name=sample_name,
-                                   description=description, creation_date=creation_date,
-                                   owner_orcid=owner_orcid, owner_id=owner_id,
-                                   project_id=project_id, sample_type=sample_type,
-                                   parents=parents, children=children)
-
-    @_deprecated("client.samples.create()")
-    def add_sample(self, unique_id: str = None, sample_name: str = None, description: str = None,
-                   creation_date: str = None, owner_orcid: str = None, owner_id: int = None,
-                   project_id: str = None, sample_type: str = None,
-                   parents: List[Dict] = [], children: List[Dict] = []) -> Dict:
-        """Backward compatible: Use client.samples.create() instead."""
-        return self.samples.create(unique_id=unique_id, sample_name=sample_name,
-                                   description=description, creation_date=creation_date,
-                                   owner_orcid=owner_orcid, owner_id=owner_id,
-                                   project_id=project_id, sample_type=sample_type,
-                                   parents=parents, children=children)
-    
-    @_deprecated("client.samples.remove_from_dataset()")
-    def remove_sample_from_dataset(self, dataset_id: str, sample_id: str) -> Dict:
-        """Backward compatible: Use client.samples.remove_from_dataset() instead."""
-        return self.samples.remove_from_dataset(dataset_id, sample_id)
-    
-
-    @_deprecated("client.samples.add_to_dataset()")
-    def add_sample_to_dataset(self, dataset_id: str, sample_id: str) -> Dict:
-        """Backward compatible: Use client.samples.add_to_dataset() instead."""
-        return self.samples.add_to_dataset(dataset_id, sample_id)
-    
-    # make them methods mirrored
-    add_dataset_to_sample = add_sample_to_dataset
-    remove_dataset_from_sample = remove_sample_from_dataset
-
-    @_deprecated("client.samples.link()")
-    def link_samples(self, parent_id: str, child_id: str):
-        """Backward compatible: Use client.samples.link() instead."""
-        return self.samples.link(parent_id, child_id)
-    
-    #%% DATASET METHODS (DEPRECATED)
-
-    @_deprecated("client.datasets.get()")
-    def get_dataset(self, dsid: str, include_metadata: bool = False) -> Dict:
-        """Backward compatible: Use client.datasets.get() instead."""
-        return self.datasets.get(dsid, include_metadata=include_metadata)
-    
-    @_deprecated("client.datasets.create()")
-    def create_new_dataset(self,
-                            dataset: Dataset,
-                            scientific_metadata: Optional[dict] = {},
-                            keywords: List[str] = [],
-                            get_user_info_function = None,
-                            verbose: bool = False) -> Dict:
-        """Backward compatible: Use client.datasets.create() instead."""
-        return self.datasets.create(dataset,
-                                   scientific_metadata=scientific_metadata,
-                                   keywords=keywords,
-                                   verbose=verbose)
-
-    @_deprecated("client.datasets.create()")
-    def create_new_dataset_from_files(self,
-                                     dataset: Dataset,
-                                     files_to_upload: List[str],
-                                     scientific_metadata: Optional[dict] = None,
-                                     keywords: List[str] = [],
-                                     get_user_info_function = None,
-                                     ingestor: str = 'ApiUploadIngestor',
-                                     verbose: bool = False,
-                                     wait_for_ingestion_response: bool = True) -> Dict:
-        """Backward compatible: Use client.datasets.create() with files_to_upload instead."""
-        return self.datasets.create(dataset,
-                                   scientific_metadata=scientific_metadata,
-                                   keywords=keywords,
-                                   verbose=verbose,
-                                   files_to_upload=files_to_upload,
-                                   ingestor=ingestor,
-                                   wait_for_ingestion_response=wait_for_ingestion_response)
-    
-    @_deprecated("client.datasets.list_children()")
-    def list_children_of_dataset(self, parent_dataset_id: str, limit = DEFAULT_LIMIT, **kwargs) -> List[Dict]:
-        """Backward compatible: Use client.datasets.list_children() instead."""
-        return self.datasets.list_children(parent_dataset_id, limit=limit, **kwargs)
-
-
-    @_deprecated("client.datasets.list_parents()")
-    def list_parents_of_dataset(self, child_dataset_id: str, limit = DEFAULT_LIMIT, **kwargs) -> List[Dict]:
-        """Backward compatible: Use client.datasets.list_parents() instead."""
-        return self.datasets.list_parents(child_dataset_id, limit=limit, **kwargs)
-    
-    @_deprecated("client.datasets.list()")
-    def list_datasets(self, sample_id: Optional[str] = None, include_metadata: bool = False,
-                     limit: int = DEFAULT_LIMIT, **kwargs) -> List[Dict]:
-        """Backward compatible: Use client.datasets.list() instead."""
-        return self.datasets.list(sample_id=sample_id, include_metadata=include_metadata,
-                                 limit=limit, **kwargs)
-
-    @_deprecated("client.datasets.update()")
-    def update_dataset(self, dsid: str, **updates) -> Dict:
-        """Backward compatible: Use client.datasets.update() instead."""
-        return self.datasets.update(dsid, **updates)
-
-
-    @_deprecated("client.datasets.get_download_links()")
-    def get_dataset_download_links(self, dsid: str):
-        """Backward compatible: Use client.datasets.get_download_links() instead."""
-        return self.datasets.get_download_links(dsid)
-
-    @_deprecated("client.datasets.download()")
-    def download_dataset(self, dsid: str, file_name: Optional[str] = None,
-                        output_dir: Optional[str] = 'crucible-downloads',
-                        overwrite_existing: bool = True) -> List[str]:
-        """Backward compatible: Use client.datasets.download() instead."""
-        return self.datasets.download(dsid, file_name=file_name,
-                                     output_dir=output_dir,
-                                     overwrite_existing=overwrite_existing)
-
-    @_removed("SciCat upload functionality has been removed from the Crucible API.")
-    def request_scicat_upload(self, dsid: str, wait_for_response: bool = False, overwrite_data: bool = False) -> Dict:
-        pass
-
-    @_deprecated("client.datasets.get_access_groups()")
-    def get_dataset_access_groups(self, dsid: str) -> List[str]:
-        """Backward compatible: Use client.datasets.get_access_groups() instead."""
-        return self.datasets.get_access_groups(dsid)
-
-    @_deprecated("client.datasets.get_scientific_metadata()")
-    def get_scientific_metadata(self, dsid: str) -> Dict:
-        """Backward compatible: Use client.datasets.get_scientific_metadata() instead."""
-        return self.datasets.get_scientific_metadata(dsid)
-
-    @_deprecated("client.datasets.update_scientific_metadata()")
-    def update_scientific_metadata(self, dsid: str, metadata: Dict, overwrite = False) -> Dict:
-        """Backward compatible: Use client.datasets.update_scientific_metadata() instead."""
-        return self.datasets.update_scientific_metadata(dsid, metadata, overwrite=overwrite)
-
-    @_deprecated("client.datasets.get_thumbnails()")
-    def get_thumbnails(self, dsid: str, limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Backward compatible: Use client.datasets.get_thumbnails() instead."""
-        return self.datasets.get_thumbnails(dsid, limit=limit)
-
-    @_deprecated("client.datasets.add_thumbnail()")
-    def add_thumbnail(self, dsid: str, file_path: str, thumbnail_name: str = None) -> Dict:
-        """Backward compatible: Use client.datasets.add_thumbnail() instead."""
-        return self.datasets.add_thumbnail(dsid, file_path, thumbnail_name=thumbnail_name)
-
-    @_deprecated("client.datasets.delete_thumbnail()")
-    def delete_thumbnail(self, dsid: str, thumbnail_id: int) -> Dict:
-        """Backward compatible: Use client.datasets.delete_thumbnail() instead."""
-        return self.datasets.delete_thumbnail(dsid, thumbnail_id)
-    
-    @_deprecated("client.datasets.get_associated_files(dsid)")
-    def get_associated_files(self, dsid: str, **kwargs) -> List[Dict]:
-        """Backward compatible: Use client.datasets.get_associated_files() instead."""
-        return self.datasets.get_associated_files(dsid)
-
-    @_deprecated("client.datasets.add_associated_file()")
-    def add_associated_file(self, dsid: str, file_path: str, filename: str = None) -> Dict:
-        """Backward compatible: Use client.datasets.add_associated_file() instead."""
-        return self.datasets.add_associated_file(dsid, file_path, filename=filename)
-    
-    @_deprecated("client.datasets.get_keywords()")
-    def get_keywords(self, dsid: str = None, limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Backward compatible: Use client.datasets.get_keywords() instead."""
-        return self.datasets.get_keywords(dsid=dsid, limit=limit)
-
-    @_deprecated("client.datasets.add_keyword()")
-    def add_dataset_keyword(self, dsid: str, keyword: str) -> Dict:
-        """Backward compatible: Use client.datasets.add_keyword() instead."""
-        return self.datasets.add_keyword(dsid, keyword)
-
-    @_deprecated("client.datasets.delete()")
-    def delete_dataset(self, dsid: str) -> Dict:
-        """Backward compatible: Use client.datasets.delete() instead."""
-        return self.datasets.delete(dsid)
-
-    @_removed("Google Drive location functionality has been removed from the Crucible API.")
-    def get_google_drive_location(self, dsid: str) -> List[Dict]:
-        pass
-
-    @_removed("Google Drive location functionality has been removed from the Crucible API.")
-    def add_google_drive_location(self, dsid: str, drive_info: Dict) -> None:
-        pass
-
-    @_deprecated("client.datasets.update_ingestion_status()")
-    def update_ingestion_status(self, dsid: str, reqid: str, status: str, timezone: str = "America/Los_Angeles"):
-        """Backward compatible: Use client.datasets.update_ingestion_status() instead."""
-        return self.datasets.update_ingestion_status(reqid, status, timezone=timezone)
-
-    @_removed("SciCat upload status functionality has been removed from the Crucible API.")
-    def update_scicat_upload_status(self, dsid: str, reqid: str, status: str, timezone: str = "America/Los_Angeles"):
-        pass
-
-    @_removed("Transfer status functionality has been removed from the Crucible API.")
-    def update_transfer_status(self, dsid: str, reqid: str, status: str, timezone: str = "America/Los_Angeles"):
-        pass
-    
-    @_deprecated("client.datasets.link_parent_child()")
-    def link_datasets(self, parent_dataset_id: str, child_dataset_id: str) -> Dict:
-        """Backward compatible: Use client.datasets.link_parent_child() instead."""
-        return self.datasets.link_parent_child(parent_dataset_id, child_dataset_id)
-    
-    @_deprecated("client.datasets.request_carrier_segmentation()")
-    def request_carrier_segmentation(self, dataset_id):
-        """Backward compatible: Use client.datasets.request_carrier_segmentation() instead."""
-        return self.datasets.request_carrier_segmentation(dataset_id)
-    
-    #%% INSTRUMENT METHODS (DEPRECATED)
-
-    @_deprecated("client.instruments.list()")
-    def list_instruments(self, limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Backward compatible: Use client.instruments.list() instead."""
-        return self.instruments.list(limit=limit)
-
-
-    @_deprecated("client.instruments.get()")
-    def get_instrument(self, instrument_name: str = None, instrument_id: str = None) -> Dict:
-        """Backward compatible: Use client.instruments.get() instead."""
-        return self.instruments.get(instrument_name=instrument_name, instrument_id=instrument_id)
-
-
-    @_deprecated("client.instruments.get_or_create()")
-    def get_or_add_instrument(self, instrument_name: str, location: str = None, instrument_owner: str = None) -> Dict:
-        """Backward compatible: Use client.instruments.get_or_create() instead."""
-        return self.instruments.get_or_create(instrument_name, location=location, instrument_owner=instrument_owner)
-    
-    #%% USER METHODS (DEPRECATED)
-
-    @_deprecated("client.users.get()")
-    def get_user(self, orcid: str = None, email: str = None) -> Dict:
-        """Backward compatible: Use client.users.get() instead."""
-        return self.users.get(orcid=orcid, email=email)
-
-    @_deprecated("client.users.create()")
-    def add_user(self, user_info: Dict) -> Dict:
-        """Backward compatible: Use client.users.create() instead."""
-        return self.users.create(user_info)

--- a/crucible/client.py
+++ b/crucible/client.py
@@ -658,10 +658,10 @@ class CrucibleClient:
         """Backward compatible: Use client.datasets.delete_thumbnail() instead."""
         return self.datasets.delete_thumbnail(dsid, thumbnail_id)
     
-    @_deprecated("client.datasets.list_files(dsid)")
+    @_deprecated("client.datasets.get_associated_files(dsid)")
     def get_associated_files(self, dsid: str, **kwargs) -> List[Dict]:
-        """Backward compatible: Use client.datasets.list_files(dsid) instead."""
-        return self.datasets.list_files(dsid=dsid)
+        """Backward compatible: Use client.datasets.get_associated_files() instead."""
+        return self.datasets.get_associated_files(dsid)
 
     @_deprecated("client.datasets.add_associated_file()")
     def add_associated_file(self, dsid: str, file_path: str, filename: str = None) -> Dict:

--- a/crucible/client.py
+++ b/crucible/client.py
@@ -135,36 +135,8 @@ class CrucibleClient:
             return response
     
     def _wait_for_request_completion(self, reqid: str, sleep_interval: int = 1) -> Dict:
-        """Wait for a request to complete by polling its status.
-
-        Args:
-            reqid (str): Request ID
-            sleep_interval (int): Seconds between status checks
-
-        Returns:
-            Dict: Final request status information
-        """
-        req_info = self._get_request_status(reqid)
-        logger.info(f"Waiting for ingestion request to complete...")
-
-        while req_info['status'] in ['requested', 'started']:
-            time.sleep(sleep_interval)
-            req_info = self._get_request_status(reqid)
-            logger.info(f"Current status: {req_info['status']}")
-
-        logger.info(f"Request completed with status: {req_info['status']}")
-        return req_info
-    
-    def _get_request_status(self, reqid: str) -> Dict:
-        """Get the status of any type of request.
-
-        Args:
-            reqid (str): Request ID
-
-        Returns:
-            Dict: Request status information
-        """
-        return self._request('get', f'/ingestion_requests/{reqid}')
+        """Internal: delegate to client.ingestions.wait()."""
+        return self.ingestions.wait(reqid, sleep_interval=sleep_interval)
 
     
     #%% GENERIC METHODS

--- a/crucible/resources/__init__.py
+++ b/crucible/resources/__init__.py
@@ -9,6 +9,7 @@ while maintaining backward compatibility with the original flat API.
 
 from .files import FileOperations
 from .datasets import DatasetOperations  # no longer inherits FileOperations
+from .ingestion import IngestionOperations
 from .samples import SampleOperations
 from .projects import ProjectOperations
 from .users import UserOperations

--- a/crucible/resources/__init__.py
+++ b/crucible/resources/__init__.py
@@ -8,7 +8,7 @@ while maintaining backward compatibility with the original flat API.
 """
 
 from .files import FileOperations
-from .datasets import DatasetOperations
+from .datasets import DatasetOperations  # no longer inherits FileOperations
 from .samples import SampleOperations
 from .projects import ProjectOperations
 from .users import UserOperations

--- a/crucible/resources/account.py
+++ b/crucible/resources/account.py
@@ -22,6 +22,26 @@ class AccountOperations(BaseResource):
     All methods require a valid API key but do not require admin permissions.
     """
 
+    def whoami(self) -> Dict:
+        """Return full auth context for the current API key.
+
+        Returns ORCID, access group list, and user profile in one response.
+        For just the user profile use account.profile().
+
+        Returns:
+            Dict: user_unique_id, access_group_ids, user_info (UserRead)
+        """
+        result = self._request('get', '/account')
+        # Normalize field renames from API v2 transition so callers work against
+        # both API versions without separate handling.
+        user_info = result.get('user_info') or {}
+        is_service = user_info.get('is_service_account', False)
+        if not is_service and 'orcid' not in user_info and 'unique_id' in user_info:
+            user_info['orcid'] = user_info['unique_id']
+        if 'user_unique_id' in result and 'access_group_name' not in result:
+            result['access_group_name'] = result['user_unique_id']
+        return result
+
     def profile(self) -> Dict:
         """Return the authenticated caller's own user profile.
 

--- a/crucible/resources/base.py
+++ b/crucible/resources/base.py
@@ -6,9 +6,12 @@ Base resource class for Crucible API operations.
 Provides shared functionality for all resource operation classes.
 """
 
+# typing
+from typing import Optional, List, Dict, Tuple
 
+# internal modules
 from ..constants import DEFAULT_LIMIT
-
+from ..utils.deprecation import _deprecated
 
 class BaseResource:
     """Base class for resource-specific operations.
@@ -93,7 +96,7 @@ class BaseResource:
 
         return items[:need]
 
-    def search_scientific_metadata(self, q: str, limit: int = 50) -> list:
+    def search_metadata(self, q: str, limit: int = 50) -> list:
         """Full-text search across scientific metadata of all accessible resources.
 
         Results are ranked by relevance and may include datasets or samples.
@@ -105,6 +108,11 @@ class BaseResource:
         """
         return self._request('get', '/resources/metadata/search',
                              params={"q": q, "limit": limit})
+
+    @_deprecated("search_metadata()")
+    def search_scientific_metadata(self, q: str, limit: int = 50) -> list:
+        """Deprecated: use search_metadata() instead."""
+        return self.search_metadata(q, limit=limit)
 
     def get_scientific_metadata(self, resource_id: str) -> dict:
         """Get scientific metadata for a resource."""
@@ -125,3 +133,38 @@ class BaseResource:
         if overwrite:
             return self._request('post', f'/resources/{resource_id}/metadata', json=metadata, params = {'overwrite':overwrite})
         return self._request('patch', f'/resources/{resource_id}/metadata', json=metadata)
+
+
+#%% access group methods
+
+    def get_access_groups(self, mfid: str) -> List[str]:
+        """Get list of access groups for a dataset.
+
+        **Requires admin permissions.**
+
+        Args:
+            dsid (str): Dataset unique identifier
+
+        Returns:
+            List[str]: Access group names
+        """
+        groups = self._request('get', f'/resources/{mfid}/access_groups')
+        return [group['group_name'] for group in groups]
+
+    def add_access_group(self, mfid: str, group_name: str,
+                         read: bool = True, write: bool = False) -> Dict:
+        """Add an access group to a dataset.
+
+        **Requires admin permissions.**
+
+        Args:
+            dsid (str): Dataset unique identifier
+            group_name (str): Name of the access group to add
+            read (bool): Grant read access (default: True)
+            write (bool): Grant write access (default: False)
+
+        Returns:
+            Dict: Created ACL entry
+        """
+        params = {"group_name": group_name, "read": read, "write": write}
+        return self._request('post', f'/resources/{mfid}/access_groups', params=params)

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -20,6 +20,9 @@ from .base import BaseResource
 from ..constants import DEFAULT_LIMIT
 from ..utils.deprecation import _deprecated
 
+# upload/download
+from .gcs.upload import upload_file_gcs
+
 # set up logging
 logger = logging.getLogger(__name__)
 
@@ -28,8 +31,6 @@ class DatasetOperations(BaseResource):
     """Dataset-related API operations.
 
     Access via: client.datasets.get(), client.datasets.list(), etc.
-    File operations (upload, download, thumbnails, ingestion) are inherited
-    from FileOperations and also available via client.files.*.
     """
 
     @staticmethod
@@ -189,89 +190,8 @@ class DatasetOperations(BaseResource):
         """
         return self._request('patch', f'/datasets/{dsid}', json=updates)
 
-    def delete(self, dsid: str) -> Dict:
-        """Delete a dataset.
-
-        Args:
-            dsid (str): Dataset unique identifier
-
-        Returns:
-            Dict: Deletion confirmation
-        """
-        return self._request('delete', f'/datasets/{dsid}')
-
-    def get_access_groups(self, dsid: str) -> List[str]:
-        """Get list of access groups for a dataset.
-
-        **Requires admin permissions.**
-
-        Args:
-            dsid (str): Dataset unique identifier
-
-        Returns:
-            List[str]: Access group names
-        """
-        groups = self._request('get', f'/datasets/{dsid}/access_groups')
-        return [group['group_name'] for group in groups]
-
-    def add_access_group(self, dsid: str, group_name: str,
-                         read: bool = True, write: bool = False) -> Dict:
-        """Add an access group to a dataset.
-
-        **Requires admin permissions.**
-
-        Args:
-            dsid (str): Dataset unique identifier
-            group_name (str): Name of the access group to add
-            read (bool): Grant read access (default: True)
-            write (bool): Grant write access (default: False)
-
-        Returns:
-            Dict: Created ACL entry
-        """
-        params = {"group_name": group_name, "read": read, "write": write}
-        return self._request('post', f'/datasets/{dsid}/access_groups', params=params)
-
-    @_deprecated("create() with files_to_upload parameter")
-    def create_from_files(self, dataset, files_to_upload: List[str],
-                         scientific_metadata: Optional[Dict] = None,
-                         keywords: Optional[List[str]] = None,
-                         get_user_info_function=None,
-                         ingestor: str = 'ApiUploadIngestor',
-                         verbose: bool = False,
-                         wait_for_ingestion_response: bool = True) -> Dict:
-        """Build a new dataset with file upload and ingestion.
-
-        .. deprecated::
-            Use :meth:`create` with files_to_upload parameter instead.
-
-        Args:
-            dataset: Dataset object with dataset details
-            files_to_upload (List[str]): List of file paths to upload
-            scientific_metadata (dict, optional): Scientific metadata
-            keywords (list, optional): Keywords to associate with dataset
-            get_user_info_function (callable, optional): Function to get user info
-            ingestor (str): Ingestion class to use (default: 'ApiUploadIngestor')
-            verbose (bool): Enable verbose output
-            wait_for_ingestion_response (bool): Wait for ingestion to complete
-
-        Returns:
-            Dict: created_record, scientific_metadata_record, ingestion_request, uploaded_files
-        """
-        return self.create(dataset=dataset,
-                          scientific_metadata=scientific_metadata,
-                          keywords=keywords,
-                          verbose=verbose,
-                          files_to_upload=files_to_upload,
-                          ingestor=ingestor,
-                          wait_for_ingestion_response=wait_for_ingestion_response)
-
-    @_deprecated("list_files(dsid)")
-    def get_associated_files(self, dsid: str) -> List[Dict]:
-        """Get associated files for a dataset.
-
-        .. deprecated::
-            Use :meth:`list_files` with the ``dsid`` argument instead.
+    def list_files(self, dsid: str) -> List[Dict]:
+        """List files attached to a dataset.
 
         Args:
             dsid: Dataset unique identifier
@@ -280,7 +200,28 @@ class DatasetOperations(BaseResource):
             List[Dict]: File records (mfid, filename, storage_path, size, sha256_hash, dataset_mfid).
                 storage_path is null until the file has been ingested.
         """
-        return self.list_files(dsid=dsid)
+        return self._request('get', f'/datasets/{dsid}/files')
+
+    def search(self, q: str, project_id: Optional[str] = None,
+               limit: int = 20) -> List[Dict]:
+        """Fuzzy name search across datasets. Available to all authenticated users.
+
+        Matches against dataset_name. Returns datasets the caller can read.
+        For scientific metadata search use search_metadata().
+
+        Args:
+            q: Search term (min 3 chars). Typo-tolerant — "pero" finds "perovskite".
+            project_id: Optional project to scope results to.
+            limit: Max results (default 20, max 50).
+
+        Returns:
+            List[Dict]: Matching DatasetResponse records, ranked by relevance.
+        """
+        params = {'q': q, 'limit': limit}
+        if project_id:
+            params['project_id'] = project_id
+        result = self._request('get', '/datasets/search', params=params)
+        return result.get('items', result) if isinstance(result, dict) else result
 
     # Keyword Methods
     def get_keywords(self, dsid: Optional[str] = None, limit: int = DEFAULT_LIMIT) -> List[Dict]:
@@ -293,10 +234,7 @@ class DatasetOperations(BaseResource):
         Returns:
             List[Dict]: Keyword objects with keyword text and num_datasets counts
         """
-        if dsid is None:
-            return self._request('get', '/keywords')
-        else:
-            return self._request('get', f'/datasets/{dsid}/keywords')
+        return self._request('get', f'/datasets/{dsid}/keywords')
 
     def add_keyword(self, dsid: str, keyword: str) -> Dict:
         """Add a keyword to a dataset.
@@ -309,7 +247,6 @@ class DatasetOperations(BaseResource):
             Dict: Keyword object with updated usage count
         """
         return self._request('post', f'/datasets/{dsid}/keywords', params={'keyword': keyword})
-
 
     # Dataset Linking Methods
     def add_sample(self, dataset_id: str, sample_id: str) -> Dict:
@@ -432,25 +369,13 @@ class DatasetOperations(BaseResource):
         result = self._request('post', f"/datasets/{dsid}/rga_analysis")
         return result
 
-
+    @_deprecated("client.graphs.get")
     def graph(self, dataset_id: str, recursive: bool = False, as_networkx: bool = False):
-        """Return the graph of entities connected to this dataset.
-
-        Delegates to client.graphs.get(). See GraphOperations.get() for full docs.
-
-        Args:
-            dataset_id (str): Dataset unique identifier.
-            recursive (bool): If True, traverse the full connected component.
-            as_networkx (bool): Return a networkx DiGraph if True.
-
-        Returns:
-            dict | networkx.DiGraph: Node-link graph data.
-        """
         return self._client.graphs.get(dataset_id, recursive=recursive, as_networkx=as_networkx)
 
     #%% Upload Methods
 
-    def add_file_to_dataset(self, dsid: str, file_path: str,
+    def add_file(self, dsid: str, file_path: str,
                             ingestion_class: Optional[str] = None,
                             wait_for_ingestion_response: bool = False,
                             multipart: bool = True,
@@ -475,76 +400,39 @@ class DatasetOperations(BaseResource):
         file_size = os.path.getsize(file_path)
         filename  = os.path.basename(file_path)
 
-        file_record, was_existing = self._upload_file_gcs(dsid, file_path, multipart=multipart,
-                                                          chunk_size_mb=chunk_size_mb,
-                                                          max_workers=max_workers)
+        file_record, was_existing = upload_file_gcs(self._client, dsid, file_path,
+                                                    multipart=multipart,
+                                                    chunk_size_mb=chunk_size_mb,
+                                                    max_workers=max_workers)
 
         stored_filename = file_record.get('filename', filename)
         file_id         = file_record.get('mfid')
 
-        if was_existing and self._has_successful_ingestion(file_id):
+        if was_existing and self._client.files._has_successful_ingestion(file_id):
             logger.info(f"{stored_filename} already ingested successfully; skipping ingestion")
             return {'associated_file': file_record, 'ingestion_request': None}
 
-        ingestion_request = self._request_ingestion(
-            dsid, file_id, stored_filename, file_size,
+        ingestion_request = self._client.files.request_ingestion(
+            file_id,
             ingestion_class=ingestion_class,
-            wait_for_ingestion_response=wait_for_ingestion_response,
+            wait_for_response=wait_for_ingestion_response,
         )
         return {'associated_file': file_record, 'ingestion_request': ingestion_request}
 
-    def _request_ingestion(self, dsid: str, file_id: str, filename: str,
-                           file_size: int, ingestion_class: Optional[str] = None,
-                           wait_for_ingestion_response: bool = False) -> Dict:
-        """Request ingestion of an already-uploaded file."""
-        ingest_params = {'filename': filename, 'file_size': file_size}
-        if ingestion_class:
-            ingest_params['ingestion_class'] = ingestion_class
+    @_deprecated("client.datasets.add_file")
+    def add_file_to_dataset(self, dsid: str, file_path: str,
+                            ingestion_class: Optional[str] = None,
+                            wait_for_ingestion_response: bool = False,
+                            multipart: bool = True,
+                            chunk_size_mb: Optional[int] = None,
+                            max_workers: Optional[int] = None) -> Dict:
+        return self.add_file(dsid=dsid, file_path=file_path,
+                             ingestion_class=ingestion_class,
+                             wait_for_ingestion_response=wait_for_ingestion_response,
+                             multipart=multipart,
+                             chunk_size_mb=chunk_size_mb,
+                             max_workers=max_workers)
 
-        logger.info(f"Requesting ingestion for {filename}"
-                    + (f" (class={ingestion_class})" if ingestion_class else ""))
-
-        ingestion_request = self._request('post', f'/datasets/{dsid}/files/{file_id}/ingest',
-                                          params=ingest_params)
-
-        logger.debug(f"Ingestion request created: id={ingestion_request.get('id')}, "
-                     f"status={ingestion_request.get('status')}")
-
-        if wait_for_ingestion_response and ingestion_request:
-            self._client._wait_for_request_completion(ingestion_request['id'])
-
-        return ingestion_request
-
-    def _has_successful_ingestion(self, file_id: Optional[str]) -> bool:
-        if not file_id:
-            return False
-        resp = self.get_ingestion_requests(file_id=file_id)
-        items = resp.get('items', []) if isinstance(resp, dict) else (resp or [])
-        return any(r.get('status') == 'complete' for r in items)
-
-    def _upload_file_gcs(self, dsid: str, file_path: str, multipart: bool = True,
-                         chunk_size_mb: Optional[int] = None,
-                         max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
-        """Dispatch to multipart or resumable GCS upload."""
-        from .gcs.upload import upload_file_gcs
-        return upload_file_gcs(self._client, dsid, file_path,
-                                multipart=multipart,
-                                chunk_size_mb=chunk_size_mb,
-                                max_workers=max_workers)
-
-    def _upload_file_gcs_multipart(self, dsid: str, file_path: str,
-                                    chunk_size_mb: Optional[int] = None,
-                                    max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
-        """Parallel multipart upload. Delegates to crucible.resources.gcs.upload."""
-        from .gcs.upload import upload_file_gcs_multipart
-        return upload_file_gcs_multipart(self._client, dsid, file_path,
-                                          chunk_size_mb=chunk_size_mb,
-                                          max_workers=max_workers)
-
-    def _upload_file_gcs_resumable(self, dsid: str, file_path: str) -> Tuple[Dict, bool]:
-        """Sequential resumable upload. Delegates to crucible.resources.gcs.upload."""
-        from .gcs.upload import upload_file_gcs_resumable
-        return upload_file_gcs_resumable(self._client, dsid, file_path)
 
     #%% Download Methods
 
@@ -572,73 +460,36 @@ class DatasetOperations(BaseResource):
                      include: Optional[List[str]] = None,
                      exclude: Optional[List[str]] = None) -> List[str]:
         """Download ingested files for a dataset. Returns list of downloaded paths."""
-        import tempfile
-
-        all_files = self.get_associated_files(dsid)
-        prefix_sp = f'mf-storage-prod/{dsid}/'
-        ingested  = [f for f in all_files if f.get('storage_path')]
-
-        def _bare_name(f: Dict) -> str:
-            sp = f.get('storage_path', '')
-            return sp[len(prefix_sp):] if sp.startswith(prefix_sp) else os.path.basename(sp)
-
-        if include:
-            ingested = [f for f in ingested if any(fnmatch.fnmatch(_bare_name(f), p) for p in include)]
-        if exclude:
-            ingested = [f for f in ingested if not any(fnmatch.fnmatch(_bare_name(f), p) for p in exclude)]
-
-        if not ingested:
-            return []
-
-        link_map  = self.get_download_links(dsid)
-        downloads = []
-
-        for file_meta in ingested:
-            name       = _bare_name(file_meta)
-            signed_url = link_map.get(file_meta.get('mfid'))
-            if not signed_url:
-                logger.warning(f"No download URL for {name}, skipping")
-                continue
-
-            download_path = os.path.join(output_dir, name)
-            if not overwrite_existing and os.path.exists(download_path):
-                downloads.append(download_path)
-                continue
-
-            os.makedirs(os.path.dirname(download_path), exist_ok=True)
-            response = self._client._session.get(signed_url, stream=True)
-            response.raise_for_status()
-            tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(download_path))
-            try:
-                with os.fdopen(tmp_fd, 'wb') as f:
-                    for chunk in response.iter_content(chunk_size=1024 * 1024):
-                        f.write(chunk)
-                os.replace(tmp_path, download_path)
-            except Exception:
-                os.unlink(tmp_path)
-                raise
-            downloads.append(download_path)
-
-        return downloads
+        from .gcs.download import download_dataset_files
+        return download_dataset_files(
+            self._client, dsid, output_dir,
+            link_map=self.get_download_links(dsid),
+            all_files=self.list_files(dsid),
+            overwrite_existing=overwrite_existing,
+            include=include, exclude=exclude,
+        )
 
     def download(self, dsid: str, file_name: Optional[str] = None,
-                 output_dir: Optional[str] = 'crucible-downloads',
-                 overwrite_existing: bool = True,
+                 output_dir: str = 'crucible-downloads',
+                 no_files: bool = False,
                  no_record: bool = False,
+                 overwrite_existing: bool = True,
                  include: Optional[List[str]] = None,
                  exclude: Optional[List[str]] = None) -> List[str]:
-        """Download dataset files.
+        """Download a dataset's files and optionally save its record as JSON.
 
         Args:
             dsid: Dataset unique identifier
             file_name: Deprecated. Use include=['pattern'] with glob syntax.
             output_dir: Directory to save files (default: 'crucible-downloads/')
+            no_files: Skip file download, save record.json only.
+            no_record: Skip saving record.json, just download files.
             overwrite_existing: Overwrite existing files (default: True)
             include: Glob patterns - only download matching files
             exclude: Glob patterns - skip matching files
 
         Returns:
-            List[str]: Downloaded file paths
+            List[str]: Paths of all downloaded items (record.json + data files)
         """
         if file_name is not None:
             import warnings
@@ -646,17 +497,35 @@ class DatasetOperations(BaseResource):
                 "The 'file_name' parameter is deprecated. Use include=['pattern'] instead.",
                 DeprecationWarning, stacklevel=2,
             )
-            all_files = self.get_associated_files(dsid)
-            matched   = [os.path.basename(f.get('storage_path') or f.get('filename', ''))
-                         for f in all_files
-                         if re.fullmatch(fr"({file_name})",
-                                         os.path.basename(f.get('storage_path') or f.get('filename', '')))]
+            matched = [os.path.basename(f.get('storage_path') or f.get('filename', ''))
+                       for f in self.list_files(dsid)
+                       if re.fullmatch(fr"({file_name})",
+                                       os.path.basename(f.get('storage_path') or f.get('filename', '')))]
             include = matched
 
-        return self._client.download(dsid, output_dir=output_dir, no_files=False,
-                                     no_record=no_record,
-                                     overwrite_existing=overwrite_existing,
-                                     include=include, exclude=exclude)
+        os.makedirs(output_dir, exist_ok=True)
+        downloaded = []
+
+        if not no_record:
+            record      = self.get(dsid, include_metadata=True)
+            record_dir  = os.path.join(output_dir, dsid)
+            os.makedirs(record_dir, exist_ok=True)
+            json_path   = os.path.join(record_dir, 'record.json')
+            with open(json_path, 'w') as fh:
+                import json as _json
+                _json.dump(record, fh, indent=2)
+            logger.info(f"Saved record to {json_path}")
+            downloaded.append(json_path)
+
+        if not no_files:
+            files = self._fetch_files(dsid, output_dir=output_dir,
+                                      overwrite_existing=overwrite_existing,
+                                      include=include, exclude=exclude)
+            downloaded.extend(files)
+            if files:
+                logger.info(f"Downloaded {len(files)} file(s) to {output_dir}")
+
+        return downloaded
 
     #%% Thumbnail Methods
 
@@ -690,41 +559,27 @@ class DatasetOperations(BaseResource):
         """Delete a thumbnail from a dataset."""
         return self._request('delete', f'/datasets/{dsid}/thumbnails/{thumbnail_id}')
 
-    #%% Ingestion Methods
+    #%% Ingestion Methods — deprecated, use client.ingestions.*
 
+    @_deprecated("client.ingestions.list(dsid=dsid, file_id=file_id)")
     def get_ingestion_requests(self, dsid: Optional[str] = None,
                                file_id: Optional[str] = None,
                                limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Get ingestion requests, optionally filtered by dataset or file.
+        """Deprecated: use client.ingestions.list() instead."""
+        return self._client.ingestions.list(dsid=dsid, file_id=file_id, limit=limit)
 
-        Args:
-            dsid: Filter by dataset ID
-            file_id: Filter by file MFID
-            limit: Maximum number of results
-        """
-        params = {}
-        if dsid:
-            params['dataset_id'] = dsid
-        if file_id:
-            params['file_id'] = file_id
-        return self._request('get', '/ingestion_requests', params=params or None)
-
+    @_deprecated("client.ingestions.get(reqid)")
     def get_request_status(self, reqid: str) -> Dict:
-        """Get the status of an ingestion request."""
-        return self._request('get', f'/ingestion_requests/{reqid}')
+        """Deprecated: use client.ingestions.get() instead."""
+        return self._client.ingestions.get(reqid)
 
+    @_deprecated("client.ingestions.update(reqid, status)")
     def update_ingestion_status(self, reqid: str, status: str,
                                 ingestion_githash: str = None,
                                 ingestion_class: str = None,
                                 timezone: str = "America/Los_Angeles") -> Dict:
-        """Update the status of an ingestion request. Admin only."""
-        from ..utils import get_tz_isoformat
-
-        patch_json = {'ingestion_githash': ingestion_githash, 'ingestion_class': ingestion_class}
-        if status == "complete":
-            patch_json.update({"id": reqid, "status": status,
-                                "time_completed": get_tz_isoformat(timezone)})
-        else:
-            patch_json.update({"id": reqid, "status": status})
-
-        return self._request('patch', f'/ingestion_requests/{reqid}', json=patch_json)
+        """Deprecated: use client.ingestions.update() instead."""
+        return self._client.ingestions.update(reqid, status,
+                                             ingestion_githash=ingestion_githash,
+                                             ingestion_class=ingestion_class,
+                                             timezone=timezone)

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -6,13 +6,17 @@ Dataset resource operations for Crucible API.
 Provides organized access to dataset-related API endpoints.
 """
 
+import os
+import re
+import fnmatch
 import logging
-from typing import Optional, List, Dict
+import requests
+from typing import Optional, List, Dict, Tuple
 
 import mfid
 
 # internal modules
-from .files import FileOperations
+from .base import BaseResource
 from ..constants import DEFAULT_LIMIT
 from ..utils.deprecation import _deprecated
 
@@ -20,7 +24,7 @@ from ..utils.deprecation import _deprecated
 logger = logging.getLogger(__name__)
 
 
-class DatasetOperations(FileOperations):
+class DatasetOperations(BaseResource):
     """Dataset-related API operations.
 
     Access via: client.datasets.get(), client.datasets.list(), etc.
@@ -443,3 +447,284 @@ class DatasetOperations(FileOperations):
             dict | networkx.DiGraph: Node-link graph data.
         """
         return self._client.graphs.get(dataset_id, recursive=recursive, as_networkx=as_networkx)
+
+    #%% Upload Methods
+
+    def add_file_to_dataset(self, dsid: str, file_path: str,
+                            ingestion_class: Optional[str] = None,
+                            wait_for_ingestion_response: bool = False,
+                            multipart: bool = True,
+                            chunk_size_mb: Optional[int] = None,
+                            max_workers: Optional[int] = None) -> Dict:
+        """Upload a file to a dataset and request ingestion.
+
+        Args:
+            dsid: Dataset unique identifier
+            file_path: Local path to the file
+            ingestion_class: Ingestion class for the worker (e.g. 'lammps', 'nexus').
+                Defaults to the server-side default if omitted.
+            wait_for_ingestion_response: Block until ingestion completes.
+            multipart: Use parallel multipart upload (default: True). Set to False to
+                use the sequential resumable upload (slower but simpler).
+            chunk_size_mb: Override chunk size in MiB (uses config/default if None).
+            max_workers: Override number of upload threads (uses config/default if None).
+
+        Returns:
+            Dict: {'associated_file': AssociatedFileRead, 'ingestion_request': IngestionRequest}
+        """
+        file_size = os.path.getsize(file_path)
+        filename  = os.path.basename(file_path)
+
+        file_record, was_existing = self._upload_file_gcs(dsid, file_path, multipart=multipart,
+                                                          chunk_size_mb=chunk_size_mb,
+                                                          max_workers=max_workers)
+
+        stored_filename = file_record.get('filename', filename)
+        file_id         = file_record.get('mfid')
+
+        if was_existing and self._has_successful_ingestion(file_id):
+            logger.info(f"{stored_filename} already ingested successfully; skipping ingestion")
+            return {'associated_file': file_record, 'ingestion_request': None}
+
+        ingestion_request = self._request_ingestion(
+            dsid, file_id, stored_filename, file_size,
+            ingestion_class=ingestion_class,
+            wait_for_ingestion_response=wait_for_ingestion_response,
+        )
+        return {'associated_file': file_record, 'ingestion_request': ingestion_request}
+
+    def _request_ingestion(self, dsid: str, file_id: str, filename: str,
+                           file_size: int, ingestion_class: Optional[str] = None,
+                           wait_for_ingestion_response: bool = False) -> Dict:
+        """Request ingestion of an already-uploaded file."""
+        ingest_params = {'filename': filename, 'file_size': file_size}
+        if ingestion_class:
+            ingest_params['ingestion_class'] = ingestion_class
+
+        logger.info(f"Requesting ingestion for {filename}"
+                    + (f" (class={ingestion_class})" if ingestion_class else ""))
+
+        ingestion_request = self._request('post', f'/datasets/{dsid}/files/{file_id}/ingest',
+                                          params=ingest_params)
+
+        logger.debug(f"Ingestion request created: id={ingestion_request.get('id')}, "
+                     f"status={ingestion_request.get('status')}")
+
+        if wait_for_ingestion_response and ingestion_request:
+            self._client._wait_for_request_completion(ingestion_request['id'])
+
+        return ingestion_request
+
+    def _has_successful_ingestion(self, file_id: Optional[str]) -> bool:
+        if not file_id:
+            return False
+        resp = self.get_ingestion_requests(file_id=file_id)
+        items = resp.get('items', []) if isinstance(resp, dict) else (resp or [])
+        return any(r.get('status') == 'complete' for r in items)
+
+    def _upload_file_gcs(self, dsid: str, file_path: str, multipart: bool = True,
+                         chunk_size_mb: Optional[int] = None,
+                         max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
+        """Dispatch to multipart or resumable GCS upload."""
+        from .gcs.upload import upload_file_gcs
+        return upload_file_gcs(self._client, dsid, file_path,
+                                multipart=multipart,
+                                chunk_size_mb=chunk_size_mb,
+                                max_workers=max_workers)
+
+    def _upload_file_gcs_multipart(self, dsid: str, file_path: str,
+                                    chunk_size_mb: Optional[int] = None,
+                                    max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
+        """Parallel multipart upload. Delegates to crucible.resources.gcs.upload."""
+        from .gcs.upload import upload_file_gcs_multipart
+        return upload_file_gcs_multipart(self._client, dsid, file_path,
+                                          chunk_size_mb=chunk_size_mb,
+                                          max_workers=max_workers)
+
+    def _upload_file_gcs_resumable(self, dsid: str, file_path: str) -> Tuple[Dict, bool]:
+        """Sequential resumable upload. Delegates to crucible.resources.gcs.upload."""
+        from .gcs.upload import upload_file_gcs_resumable
+        return upload_file_gcs_resumable(self._client, dsid, file_path)
+
+    #%% Download Methods
+
+    def get_download_links(self, dsid: str) -> Dict:
+        """Get signed download URLs for all ingested files in a dataset.
+
+        Returns:
+            Dict: Mapping of file MFID → signed URL. Empty dict if no ingested files.
+        """
+        try:
+            return self._request('get', f"/datasets/{dsid}/download_links")
+        except requests.exceptions.HTTPError as e:
+            if e.response is not None:
+                if e.response.status_code == 404:
+                    logger.debug(f"No ingested files in storage for dataset {dsid}")
+                    return {}
+                if e.response.status_code in (502, 503, 504):
+                    logger.warning(f"Could not retrieve download links for {dsid}: "
+                                   f"{e.response.status_code} {e.response.reason}.")
+                    return {}
+            raise
+
+    def _fetch_files(self, dsid: str, output_dir: str,
+                     overwrite_existing: bool = True,
+                     include: Optional[List[str]] = None,
+                     exclude: Optional[List[str]] = None) -> List[str]:
+        """Download ingested files for a dataset. Returns list of downloaded paths."""
+        import tempfile
+
+        all_files = self.get_associated_files(dsid)
+        prefix_sp = f'mf-storage-prod/{dsid}/'
+        ingested  = [f for f in all_files if f.get('storage_path')]
+
+        def _bare_name(f: Dict) -> str:
+            sp = f.get('storage_path', '')
+            return sp[len(prefix_sp):] if sp.startswith(prefix_sp) else os.path.basename(sp)
+
+        if include:
+            ingested = [f for f in ingested if any(fnmatch.fnmatch(_bare_name(f), p) for p in include)]
+        if exclude:
+            ingested = [f for f in ingested if not any(fnmatch.fnmatch(_bare_name(f), p) for p in exclude)]
+
+        if not ingested:
+            return []
+
+        link_map  = self.get_download_links(dsid)
+        downloads = []
+
+        for file_meta in ingested:
+            name       = _bare_name(file_meta)
+            signed_url = link_map.get(file_meta.get('mfid'))
+            if not signed_url:
+                logger.warning(f"No download URL for {name}, skipping")
+                continue
+
+            download_path = os.path.join(output_dir, name)
+            if not overwrite_existing and os.path.exists(download_path):
+                downloads.append(download_path)
+                continue
+
+            os.makedirs(os.path.dirname(download_path), exist_ok=True)
+            response = self._client._session.get(signed_url, stream=True)
+            response.raise_for_status()
+            tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(download_path))
+            try:
+                with os.fdopen(tmp_fd, 'wb') as f:
+                    for chunk in response.iter_content(chunk_size=1024 * 1024):
+                        f.write(chunk)
+                os.replace(tmp_path, download_path)
+            except Exception:
+                os.unlink(tmp_path)
+                raise
+            downloads.append(download_path)
+
+        return downloads
+
+    def download(self, dsid: str, file_name: Optional[str] = None,
+                 output_dir: Optional[str] = 'crucible-downloads',
+                 overwrite_existing: bool = True,
+                 no_record: bool = False,
+                 include: Optional[List[str]] = None,
+                 exclude: Optional[List[str]] = None) -> List[str]:
+        """Download dataset files.
+
+        Args:
+            dsid: Dataset unique identifier
+            file_name: Deprecated. Use include=['pattern'] with glob syntax.
+            output_dir: Directory to save files (default: 'crucible-downloads/')
+            overwrite_existing: Overwrite existing files (default: True)
+            include: Glob patterns - only download matching files
+            exclude: Glob patterns - skip matching files
+
+        Returns:
+            List[str]: Downloaded file paths
+        """
+        if file_name is not None:
+            import warnings
+            warnings.warn(
+                "The 'file_name' parameter is deprecated. Use include=['pattern'] instead.",
+                DeprecationWarning, stacklevel=2,
+            )
+            all_files = self.get_associated_files(dsid)
+            matched   = [os.path.basename(f.get('storage_path') or f.get('filename', ''))
+                         for f in all_files
+                         if re.fullmatch(fr"({file_name})",
+                                         os.path.basename(f.get('storage_path') or f.get('filename', '')))]
+            include = matched
+
+        return self._client.download(dsid, output_dir=output_dir, no_files=False,
+                                     no_record=no_record,
+                                     overwrite_existing=overwrite_existing,
+                                     include=include, exclude=exclude)
+
+    #%% Thumbnail Methods
+
+    def get_thumbnails(self, dsid: str, limit: int = DEFAULT_LIMIT) -> List[Dict]:
+        """Get thumbnails for a dataset."""
+        return self._request('get', f'/datasets/{dsid}/thumbnails')
+
+    def add_thumbnail(self, dsid: str, image, thumbnail_name: Optional[str] = None) -> Dict:
+        """Add a thumbnail to a dataset."""
+        import base64
+        from ..utils import data2thumbnail, is_base64
+
+        if is_base64(image):
+            thumbnail_data = {
+                'thumbnail_name': thumbnail_name or f"{dsid}_thumbnail",
+                'thumbnail_b64str': image,
+            }
+            return self._request('post', f'/datasets/{dsid}/thumbnails', json=thumbnail_data)
+
+        png_path = data2thumbnail(image)
+        if thumbnail_name is None:
+            thumbnail_name = os.path.basename(png_path)
+
+        with open(png_path, 'rb') as f:
+            thumbnail_b64str = base64.b64encode(f.read()).decode('utf-8')
+
+        thumbnail_data = {'thumbnail_name': thumbnail_name, 'thumbnail_b64str': thumbnail_b64str}
+        return self._request('post', f'/datasets/{dsid}/thumbnails', json=thumbnail_data)
+
+    def delete_thumbnail(self, dsid: str, thumbnail_id: int) -> Dict:
+        """Delete a thumbnail from a dataset."""
+        return self._request('delete', f'/datasets/{dsid}/thumbnails/{thumbnail_id}')
+
+    #%% Ingestion Methods
+
+    def get_ingestion_requests(self, dsid: Optional[str] = None,
+                               file_id: Optional[str] = None,
+                               limit: int = DEFAULT_LIMIT) -> List[Dict]:
+        """Get ingestion requests, optionally filtered by dataset or file.
+
+        Args:
+            dsid: Filter by dataset ID
+            file_id: Filter by file MFID
+            limit: Maximum number of results
+        """
+        params = {}
+        if dsid:
+            params['dataset_id'] = dsid
+        if file_id:
+            params['file_id'] = file_id
+        return self._request('get', '/ingestion_requests', params=params or None)
+
+    def get_request_status(self, reqid: str) -> Dict:
+        """Get the status of an ingestion request."""
+        return self._request('get', f'/ingestion_requests/{reqid}')
+
+    def update_ingestion_status(self, reqid: str, status: str,
+                                ingestion_githash: str = None,
+                                ingestion_class: str = None,
+                                timezone: str = "America/Los_Angeles") -> Dict:
+        """Update the status of an ingestion request. Admin only."""
+        from ..utils import get_tz_isoformat
+
+        patch_json = {'ingestion_githash': ingestion_githash, 'ingestion_class': ingestion_class}
+        if status == "complete":
+            patch_json.update({"id": reqid, "status": status,
+                                "time_completed": get_tz_isoformat(timezone)})
+        else:
+            patch_json.update({"id": reqid, "status": status})
+
+        return self._request('patch', f'/ingestion_requests/{reqid}', json=patch_json)

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -8,10 +8,9 @@ Provides organized access to dataset-related API endpoints.
 
 import os
 import re
-import fnmatch
 import logging
 import requests
-from typing import Optional, List, Dict, Tuple
+from typing import Optional, List, Dict
 
 import mfid
 
@@ -170,7 +169,7 @@ class DatasetOperations(BaseResource):
 
         for file in files_to_upload:
             logger.debug(f'Adding {file} to dataset {dsid}')
-            self.add_file_to_dataset(dsid, file, ingestion_class=ingestor, wait_for_ingestion_response=wait_for_ingestion_response)
+            self.add_file(dsid, file, ingestion_class=ingestor, wait_for_ingestion_response=wait_for_ingestion_response)
 
         result = {"created_record": new_ds_record, "scientific_metadata_record": scimd, "dsid": dsid}
         return result

--- a/crucible/resources/files.py
+++ b/crucible/resources/files.py
@@ -124,238 +124,29 @@ class FileOperations(BaseResource):
     def _upload_file_gcs(self, dsid: str, file_path: str, multipart: bool = True,
                          chunk_size_mb: Optional[int] = None,
                          max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
-        """Upload a file to a dataset.
+        """Dispatch to multipart or resumable GCS upload.
 
-        Args:
-            dsid: Dataset unique identifier
-            file_path: Local path to the file
-            multipart: If True (default), use parallel multipart upload via the GCS SDK.
-                       If False, use the sequential resumable upload.
-            chunk_size_mb: Override chunk size in MiB (uses config/default if None).
-            max_workers: Override number of upload threads (uses config/default if None).
-
-        Returns:
-            Tuple[Dict, bool]: (AssociatedFile record, was_existing).
-                was_existing is True when the file was a dedup hit and the upload was skipped.
+        Delegates to crucible.resources.gcs.upload — see that module for full docs.
         """
-        if multipart:
-            return self._upload_file_gcs_multipart(dsid, file_path,
-                                                    chunk_size_mb=chunk_size_mb,
-                                                    max_workers=max_workers)
-        return self._upload_file_gcs_resumable(dsid, file_path)
+        from .gcs.upload import upload_file_gcs
+        return upload_file_gcs(self._client, dsid, file_path,
+                                multipart=multipart,
+                                chunk_size_mb=chunk_size_mb,
+                                max_workers=max_workers)
 
     def _upload_file_gcs_multipart(self, dsid: str, file_path: str,
                                     chunk_size_mb: Optional[int] = None,
                                     max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
-        """Upload using the GCS SDK's parallel multipart upload (upload_chunks_concurrently).
-
-        Requires google-cloud-storage>=2.7.0 (pip install nano-crucible[gcs]).
-        The API vends a short-lived OAuth2 token so no GCS credentials are needed.
-
-        Args:
-            dsid: Dataset unique identifier
-            file_path: Local path to the file
-
-        Returns:
-            Dict: AssociatedFile record for the uploaded file.
-        """
-        import hashlib
-        import base64
-        import google_crc32c
-        from google.cloud import storage
-        from google.cloud.storage import transfer_manager
-        from google.oauth2.credentials import Credentials
-
-        cfg      = self._client._config
-        _CHUNK   = (chunk_size_mb or cfg.upload_chunk_size_mb) * 1024 * 1024
-        _WORKERS = max_workers or cfg.upload_max_workers
-
-        file_size = os.path.getsize(file_path)
-        filename  = os.path.basename(file_path)
-
-        logger.info(f"Uploading {filename} ({file_size / 1024**2:.1f} MB) "
-                    f"to dataset {dsid} [parallel, {_WORKERS} workers]")
-
-        # Single pre-pass: SHA256 for Crucible dedup/verify + CRC32C for
-        # post-upload integrity check against the GCS-assembled object.
-        sha = hashlib.sha256()
-        crc = google_crc32c.Checksum()
-        with open(file_path, 'rb') as f:
-            for block in iter(lambda: f.read(_CHUNK), b''):
-                sha.update(block)
-                crc.update(block)
-        sha256_hash      = sha.hexdigest()
-        local_crc32c_b64 = base64.b64encode(crc.digest()).decode()
-
-        # Initiate: get upload token (or dedup hit)
-        init = self._request('post', f'/datasets/{dsid}/upload/initiate/multipart',
-                             json={'filename': filename, 'size': file_size,
-                                   'sha256_hash': sha256_hash})
-
-        if init.get('existing_file') is not None:
-            logger.info(f"{filename} already exists in dataset {dsid}, skipping upload")
-            return init['existing_file'], True
-
-        upload_id = init['upload_id']
-
-        # Build GCS client from vended token — no user credentials needed
-        gcs = storage.Client(
-            credentials=Credentials(token=init['access_token']),
-            project=init['project'],
-        )
-        blob = gcs.bucket(init['bucket']).blob(f"{init['object_prefix']}{filename}")
-
-        logger.debug(f"Starting parallel upload: upload_id={upload_id}, "
-                     f"chunk={_CHUNK >> 20} MiB, workers={_WORKERS}")
-
-        # No per-chunk checksum flag — the SDK has a known bug where it sends
-        # the CRC32C in a way GCS rejects. We verify the final assembled object
-        # below instead, which is a stronger guarantee.
-        transfer_manager.upload_chunks_concurrently(
-            file_path,
-            blob,
-            chunk_size=_CHUNK,
-            max_workers=_WORKERS,
-            worker_type=transfer_manager.THREAD,
-        )
-
-        # Verify the assembled GCS object's CRC32C matches our local hash.
-        # GCS computes CRC32C over the full assembled byte stream, identical
-        # to a local sequential hash, so this catches any corruption in
-        # upload or server-side assembly.
-        blob.reload()
-        if blob.crc32c and blob.crc32c != local_crc32c_b64:
-            raise RuntimeError(
-                f"CRC32C mismatch for {filename} after assembly: "
-                f"local={local_crc32c_b64} gcs={blob.crc32c}"
-            )
-        logger.debug(f"CRC32C verified: {local_crc32c_b64}")
-
-        logger.info(f"Completing upload for {filename} (upload_id={upload_id})")
-        file_record = self._request('post', f'/datasets/{dsid}/upload/complete',
-                                    json={'upload_id': upload_id, 'sha256_hash': sha256_hash})
-        return file_record, False
+        """Parallel multipart upload. Delegates to crucible.resources.gcs.upload."""
+        from .gcs.upload import upload_file_gcs_multipart
+        return upload_file_gcs_multipart(self._client, dsid, file_path,
+                                          chunk_size_mb=chunk_size_mb,
+                                          max_workers=max_workers)
 
     def _upload_file_gcs_resumable(self, dsid: str, file_path: str) -> Tuple[Dict, bool]:
-        """Upload using a GCS resumable session URI (sequential, no extra dependencies).
-
-        Args:
-            dsid: Dataset unique identifier
-            file_path: Local path to the file
-
-        Returns:
-            Tuple[Dict, bool]: (AssociatedFile record, was_existing). was_existing is
-                True when the file already existed in the dataset and the byte upload
-                was skipped via server-side dedup.
-        """
-        import hashlib
-        import base64
-        import google_crc32c
-        _256K      = 256 * 1024
-        _MIN_CHUNK = 32 * 1024 * 1024  # 32 MiB floor - overrides server hint for throughput
-        _MAX_RETRIES = 3
-
-        file_size = os.path.getsize(file_path)
-        filename  = os.path.basename(file_path)
-
-        logger.info(f"Uploading {filename} ({file_size / 1024**2:.1f} MB) to dataset {dsid}")
-
-        # SHA256 for server-side dedup; CRC32C for end-to-end integrity vs GCS's
-        # response. Per-chunk x-goog-hash is unusable here — GCS treats it as the
-        # whole-object hash and rejects any multi-chunk upload.
-        sha = hashlib.sha256()
-        crc = google_crc32c.Checksum()
-        with open(file_path, 'rb') as f:
-            for block in iter(lambda: f.read(_MIN_CHUNK), b''):
-                sha.update(block)
-                crc.update(block)
-        sha256_hash = sha.hexdigest()
-        local_crc32c_b64 = base64.b64encode(crc.digest()).decode()
-
-        # Initiate resumable upload session; server returns existing_file if hash matches
-        init = self._request('post', f'/datasets/{dsid}/upload/initiate',
-                             json={'filename': filename, 'size': file_size,
-                                   'sha256_hash': sha256_hash})
-
-        if init.get('existing_file', None) is not None:
-            logger.info(f"File {filename} already exists in dataset {dsid}, skipping upload")
-            return init['existing_file'], True
-
-        upload_id  = init['upload_id']
-        uri        = init['resumable_uri']
-        raw_hint   = init.get('chunk_size_hint', _MIN_CHUNK)
-        # Use the larger of server hint and our minimum; align to GCS 256 KiB boundary
-        chunk_size = max((max(raw_hint, _MIN_CHUNK) // _256K) * _256K, _256K)
-
-        logger.debug(f"Chunked upload initiated: upload_id={upload_id}, chunk_size={chunk_size >> 20} MiB")
-
-        # Upload chunks directly to GCS (no Crucible auth needed)
-        with open(file_path, 'rb') as f:
-            offset = 0
-            while offset < file_size:
-                f.seek(offset)
-                chunk = f.read(chunk_size)
-                chunk_end = offset + len(chunk) - 1
-
-                for attempt in range(_MAX_RETRIES):
-                    resp = requests.put(
-                        uri,
-                        data=chunk,
-                        headers={
-                            'Content-Range': f'bytes {offset}-{chunk_end}/{file_size}',
-                            'Content-Length': str(len(chunk)),
-                        },
-                        timeout=120,
-                    )
-                    if resp.status_code in (200, 201):
-                        # Final chunk: response body is the GCS object resource.
-                        # Verify GCS-computed crc32c matches what we hashed locally.
-                        try:
-                            remote_crc32c = resp.json().get('crc32c')
-                        except ValueError:
-                            remote_crc32c = None
-                        if remote_crc32c and remote_crc32c != local_crc32c_b64:
-                            raise RuntimeError(
-                                f"GCS crc32c mismatch for {filename}: "
-                                f"local={local_crc32c_b64} remote={remote_crc32c}"
-                            )
-                        offset = file_size
-                        break
-                    elif resp.status_code == 308:
-                        offset = chunk_end + 1
-                        logger.debug(f"Chunk accepted, offset={offset}/{file_size}")
-                        break
-                    else:
-                        logger.warning(
-                            f"{filename} GCS chunk rejected offset={offset} "
-                            f"status={resp.status_code} attempt={attempt+1}/{_MAX_RETRIES} "
-                            f"body={resp.text[:300]}"
-                        )
-                        if attempt == _MAX_RETRIES - 1:
-                            raise RuntimeError(
-                                f"GCS chunk upload failed after {_MAX_RETRIES} attempts "
-                                f"(status {resp.status_code}): {resp.text}"
-                            )
-                        # Query GCS for confirmed offset and retry from there
-                        probe = requests.put(uri,
-                                             headers={'Content-Range': f'bytes */{file_size}'},
-                                             timeout=30)
-                        if probe.status_code in (200, 201):
-                            offset = file_size
-                            break
-                        elif probe.status_code == 308 and 'Range' in probe.headers:
-                            last_byte = int(probe.headers['Range'].split('-')[1])
-                            offset = last_byte + 1
-                        f.seek(offset)
-                        chunk = f.read(chunk_size)
-                        chunk_end = offset + len(chunk) - 1
-
-        # Register the AssociatedFile record
-        logger.info(f"Completing upload for {filename} (upload_id={upload_id})")
-        file_record = self._request('post', f'/datasets/{dsid}/upload/complete',
-                                    json={'upload_id': upload_id, 'sha256_hash': sha256_hash})
-
-        return file_record, False
+        """Sequential resumable upload. Delegates to crucible.resources.gcs.upload."""
+        from .gcs.upload import upload_file_gcs_resumable
+        return upload_file_gcs_resumable(self._client, dsid, file_path)
 
 
     def list_files(self, dsid: Optional[str] = None, limit: int = DEFAULT_LIMIT,

--- a/crucible/resources/files.py
+++ b/crucible/resources/files.py
@@ -49,6 +49,88 @@ class FileOperations(BaseResource):
             params['sha256_hash'] = sha256_hash
         return self._paginate('/files', params, limit=limit)
 
+    def download(self, file_id: str, output_dir: str = '.') -> str:
+        """Download a single file by MFID to a local directory.
+
+        Args:
+            file_id: File MFID
+            output_dir: Directory to save the file (default: current directory)
+
+        Returns:
+            str: Path of the downloaded file
+
+        Raises:
+            RuntimeError: If the file has not been ingested yet.
+        """
+        import tempfile
+
+        file_record = self.get(file_id)
+        if not file_record.get('storage_path'):
+            raise RuntimeError(f"File {file_id} has not been ingested yet — cannot download")
+
+        url = self.get_download_link(file_id)
+
+        sp       = file_record.get('storage_path', '')
+        prefix   = 'mf-storage-prod/'
+        if sp.startswith(prefix):
+            after  = sp[len(prefix):]
+            _, _, name = after.partition('/')
+        else:
+            import os as _os
+            name = _os.path.basename(file_record.get('filename') or file_id)
+
+        import os
+        output_path = os.path.join(output_dir, name)
+        os.makedirs(os.path.dirname(os.path.abspath(output_path)), exist_ok=True)
+
+        response = self._client._session.get(url, stream=True)
+        response.raise_for_status()
+
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(os.path.abspath(output_path)))
+        try:
+            with os.fdopen(tmp_fd, 'wb') as fh:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    fh.write(chunk)
+            os.replace(tmp_path, output_path)
+        except Exception:
+            os.unlink(tmp_path)
+            raise
+
+        logger.info(f"Downloaded {name} to {output_path}")
+        return output_path
+
+    def request_ingestion(self, file_id: str,
+                          ingestion_class: Optional[str] = None,
+                          wait_for_response: bool = False) -> Dict:
+        """Request ingestion of an uploaded file.
+
+        Args:
+            file_id: File MFID
+            ingestion_class: Ingestion class for the worker (e.g. 'lammps', 'nexus').
+                Defaults to the server-side default if omitted.
+            wait_for_response: Block until ingestion completes.
+
+        Returns:
+            Dict: IngestionRequest record (id, status, ...)
+        """
+        params = {}
+        if ingestion_class:
+            params['ingestion_class'] = ingestion_class
+
+        logger.info(f"Requesting ingestion for file {file_id}"
+                    + (f" (class={ingestion_class})" if ingestion_class else ""))
+
+        ingestion_request = self._request('post', f'/files/{file_id}/ingest',
+                                          params=params or None)
+
+        logger.debug(f"Ingestion request created: id={ingestion_request.get('id')}, "
+                     f"status={ingestion_request.get('status')}")
+
+        if wait_for_response and ingestion_request:
+            self._client._wait_for_request_completion(ingestion_request['id'])
+
+        return ingestion_request
+
     def get_download_link(self, file_id: str) -> str:
         """Get a signed download URL for a single file.
 

--- a/crucible/resources/files.py
+++ b/crucible/resources/files.py
@@ -1,18 +1,14 @@
 #!/usr/bin/env python3
 # -*- coding: utf-8 -*-
 """
-File operations for Crucible datasets: upload, download, thumbnails, ingestion.
+File resource operations — scoped to a single file MFID (/files/* endpoints).
 
-Accessible as client.files.* or via client.datasets.* (DatasetOperations inherits
-this class so all methods are available on both namespaces).
+For dataset-scoped file operations (upload, download, thumbnails, ingestion)
+see DatasetOperations (client.datasets.*).
 """
 
-import os
-import re
-import fnmatch
 import logging
-import requests
-from typing import Optional, List, Dict, Tuple
+from typing import Optional, List, Dict
 
 from .base import BaseResource
 from ..constants import DEFAULT_LIMIT
@@ -21,157 +17,13 @@ logger = logging.getLogger(__name__)
 
 
 class FileOperations(BaseResource):
-    """File operations scoped to a dataset: upload, download, thumbnails, ingestion.
+    """Operations on individual files by MFID.
 
-    Access via client.files.* or client.datasets.* (DatasetOperations inherits this).
-    All methods take a dataset unique ID (dsid) as their first argument.
+    Access via: client.files.get(), client.files.list(), etc.
     """
 
-    #%% Upload Methods
-
-    def add_file_to_dataset(self, dsid: str, file_path: str,
-                            ingestion_class: Optional[str] = None,
-                            wait_for_ingestion_response: bool = False,
-                            multipart: bool = True,
-                            chunk_size_mb: Optional[int] = None,
-                            max_workers: Optional[int] = None) -> Dict:
-        """Upload a file to a dataset and request ingestion.
-
-        Args:
-            dsid: Dataset unique identifier
-            file_path: Local path to the file
-            ingestion_class: Ingestion class for the worker (e.g. 'lammps', 'nexus').
-                Defaults to the server-side default if omitted.
-            wait_for_ingestion_response: Block until ingestion completes.
-            multipart: Use parallel multipart upload (default: True). Set to False to
-                use the sequential resumable upload (slower but simpler).
-
-        Returns:
-            Dict: {'associated_file': AssociatedFileRead, 'ingestion_request': IngestionRequest}
-                AssociatedFileRead includes: mfid, filename, storage_path, size, sha256_hash, dataset_mfid
-                ingestion_request is None when the file was already present and a prior
-                ingestion for it had completed, so ingestion was skipped.
-        """
-        # get file information
-        file_size = os.path.getsize(file_path)
-        filename = os.path.basename(file_path)
-        
-        # run file upload
-        file_record, was_existing = self._upload_file_gcs(dsid, file_path, multipart=multipart,
-                                                          chunk_size_mb=chunk_size_mb,
-                                                          max_workers=max_workers)
-
-
-        stored_filename = file_record.get('filename', filename)
-        file_id = file_record.get('mfid')
-
-        if was_existing and self._has_successful_ingestion(file_id):
-            logger.info(f"{stored_filename} already ingested successfully; skipping ingestion")
-            return {'associated_file': file_record, 'ingestion_request': None}
-
-        ingestion_request = self._request_ingestion(
-            dsid, file_id, stored_filename, file_size,
-            ingestion_class=ingestion_class,
-            wait_for_ingestion_response=wait_for_ingestion_response,
-        )
-
-        return {'associated_file': file_record, 'ingestion_request': ingestion_request}
-
-    def _request_ingestion(self, dsid: str, file_id: str, filename: str,
-                           file_size: int, ingestion_class: Optional[str] = None,
-                           wait_for_ingestion_response: bool = False) -> Dict:
-        """Request ingestion of an already-uploaded file.
-
-        Internal: callers should go through add_file_to_dataset(), which uploads
-        the bytes and then requests ingestion.
-
-        Args:
-            dsid: Dataset unique identifier
-            file_id: MFID of the uploaded file
-            filename: Stored filename of the uploaded file
-            file_size: Size of the file in bytes
-            ingestion_class: Ingestion class for the worker (e.g. 'lammps', 'nexus').
-                Defaults to the server-side default if omitted.
-            wait_for_ingestion_response: Block until ingestion completes.
-
-        Returns:
-            Dict: IngestionRequest record (id, status, ...)
-        """
-        ingest_params = {'filename': filename, 'file_size': file_size}
-        if ingestion_class:
-            ingest_params['ingestion_class'] = ingestion_class
-
-        logger.info(f"Requesting ingestion for {filename}"
-                    + (f" (class={ingestion_class})" if ingestion_class else ""))
-
-        ingestion_request = self._request('post', f'/datasets/{dsid}/files/{file_id}/ingest', params=ingest_params)
-
-        logger.debug(f"Ingestion request created: id={ingestion_request.get('id')}, "
-                     f"status={ingestion_request.get('status')}")
-
-        if wait_for_ingestion_response and ingestion_request:
-            self._client._wait_for_request_completion(ingestion_request['id'])
-
-        return ingestion_request
-
-    def _has_successful_ingestion(self, file_id: Optional[str]) -> bool:
-        if not file_id:
-            return False
-        resp = self.get_ingestion_requests(file_id=file_id)
-        items = resp.get('items', []) if isinstance(resp, dict) else (resp or [])
-        return any(r.get('status') == 'complete' for r in items)
-
-    def _upload_file_gcs(self, dsid: str, file_path: str, multipart: bool = True,
-                         chunk_size_mb: Optional[int] = None,
-                         max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
-        """Dispatch to multipart or resumable GCS upload.
-
-        Delegates to crucible.resources.gcs.upload — see that module for full docs.
-        """
-        from .gcs.upload import upload_file_gcs
-        return upload_file_gcs(self._client, dsid, file_path,
-                                multipart=multipart,
-                                chunk_size_mb=chunk_size_mb,
-                                max_workers=max_workers)
-
-    def _upload_file_gcs_multipart(self, dsid: str, file_path: str,
-                                    chunk_size_mb: Optional[int] = None,
-                                    max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
-        """Parallel multipart upload. Delegates to crucible.resources.gcs.upload."""
-        from .gcs.upload import upload_file_gcs_multipart
-        return upload_file_gcs_multipart(self._client, dsid, file_path,
-                                          chunk_size_mb=chunk_size_mb,
-                                          max_workers=max_workers)
-
-    def _upload_file_gcs_resumable(self, dsid: str, file_path: str) -> Tuple[Dict, bool]:
-        """Sequential resumable upload. Delegates to crucible.resources.gcs.upload."""
-        from .gcs.upload import upload_file_gcs_resumable
-        return upload_file_gcs_resumable(self._client, dsid, file_path)
-
-
-    def list_files(self, dsid: Optional[str] = None, limit: int = DEFAULT_LIMIT,
-                   sha256_hash: Optional[str] = None) -> List[Dict]:
-        """List files, optionally scoped to a single dataset.
-
-        Args:
-            dsid: If provided, list files for this dataset (GET /datasets/{dsid}/files).
-                Otherwise list files across all accessible datasets (GET /files).
-            limit: Maximum number of results (ignored when dsid is provided)
-            sha256_hash: Filter by SHA-256 hex digest (ignored when dsid is provided)
-
-        Returns:
-            List[Dict]: File records (mfid, filename, storage_path, size, sha256_hash, dataset_mfid).
-                storage_path is null until the file has been ingested.
-        """
-        if dsid is not None:
-            return self._request('get', f'/datasets/{dsid}/files')
-        params = {}
-        if sha256_hash:
-            params['sha256_hash'] = sha256_hash
-        return self._paginate('/files', params, limit=limit)
-
-    def get_file(self, file_id: str) -> Dict:
-        """Get metadata for a single associated file.
+    def get(self, file_id: str) -> Dict:
+        """Get metadata for a single file by its MFID.
 
         Args:
             file_id: File MFID
@@ -181,11 +33,24 @@ class FileOperations(BaseResource):
         """
         return self._request('get', f'/files/{file_id}')
 
+    def list(self, limit: int = DEFAULT_LIMIT,
+             sha256_hash: Optional[str] = None) -> List[Dict]:
+        """List files across all accessible datasets.
+
+        Args:
+            limit: Maximum number of results
+            sha256_hash: Filter by SHA-256 hex digest
+
+        Returns:
+            List[Dict]: File records (mfid, filename, storage_path, size, sha256_hash, dataset_mfid)
+        """
+        params = {}
+        if sha256_hash:
+            params['sha256_hash'] = sha256_hash
+        return self._paginate('/files', params, limit=limit)
+
     def get_download_link(self, file_id: str) -> str:
         """Get a signed download URL for a single file.
-
-        Prefer this over get_download_links() when the user requests a specific
-        file — avoids signing all files in the dataset.
 
         Args:
             file_id: File MFID
@@ -198,249 +63,3 @@ class FileOperations(BaseResource):
         """
         result = self._request('get', f'/files/{file_id}/download_link')
         return result['url']
-
-    #%% Download Methods
-
-    def get_download_links(self, dsid: str) -> Dict:
-        """Get signed download URLs for all ingested files in a dataset.
-
-        URLs are valid for 1 hour, require no auth, and are safe to share.
-
-        Args:
-            dsid: Dataset unique identifier
-
-        Returns:
-            Dict: Mapping of file MFID → signed URL. Only includes ingested files.
-                Empty dict if no ingested files found.
-        """
-        try:
-            return self._request('get', f"/datasets/{dsid}/download_links")
-        except requests.exceptions.HTTPError as e:
-            if e.response is not None:
-                if e.response.status_code == 404:
-                    logger.debug(f"No ingested files in storage for dataset {dsid}")
-                    return {}
-                if e.response.status_code in (502, 503, 504):
-                    logger.warning(f"Could not retrieve download links for {dsid}: "
-                                   f"{e.response.status_code} {e.response.reason}. "
-                                   "The server may be temporarily unavailable.")
-                    return {}
-            raise
-
-    def _fetch_files(self, dsid: str, output_dir: str,
-                     overwrite_existing: bool = True,
-                     include: Optional[List[str]] = None,
-                     exclude: Optional[List[str]] = None) -> List[str]:
-        """Download files for a dataset into output_dir. Returns list of downloaded paths."""
-        import tempfile
-
-        all_files = self.list_files(dsid=dsid)
-
-        # Only ingested files have a storage_path and are downloadable
-        prefix_sp = f'mf-storage-prod/{dsid}/'
-        ingested = [f for f in all_files if f.get('storage_path')]
-
-        def _bare_name(f: Dict) -> str:
-            sp = f.get('storage_path', '')
-            return sp[len(prefix_sp):] if sp.startswith(prefix_sp) else os.path.basename(sp)
-
-        if include:
-            ingested = [f for f in ingested if any(fnmatch.fnmatch(_bare_name(f), p) for p in include)]
-        if exclude:
-            ingested = [f for f in ingested if not any(fnmatch.fnmatch(_bare_name(f), p) for p in exclude)]
-
-        if not ingested:
-            return []
-
-        # Bulk-fetch signed URLs; keys are MFIDs
-        link_map = self.get_download_links(dsid)
-
-        downloads = []
-        for file_meta in ingested:
-            name       = _bare_name(file_meta)
-            signed_url = link_map.get(file_meta.get('mfid'))
-            if not signed_url:
-                logger.warning(f"No download URL for {name}, skipping")
-                continue
-
-            download_path = os.path.join(output_dir, name)
-            if not overwrite_existing and os.path.exists(download_path):
-                downloads.append(download_path)
-                continue
-
-            os.makedirs(os.path.dirname(download_path), exist_ok=True)
-            response = self._client._session.get(signed_url, stream=True)
-            response.raise_for_status()
-            # Write to a temp file then atomically rename to avoid corrupt partial files
-            tmp_fd, tmp_path = tempfile.mkstemp(dir=os.path.dirname(download_path))
-            try:
-                with os.fdopen(tmp_fd, 'wb') as f:
-                    for chunk in response.iter_content(chunk_size=1024 * 1024):
-                        f.write(chunk)
-                os.replace(tmp_path, download_path)
-            except Exception:
-                os.unlink(tmp_path)
-                raise
-            downloads.append(download_path)
-
-        return downloads
-
-    def download(self, dsid: str, file_name: Optional[str] = None,
-                 output_dir: Optional[str] = 'crucible-downloads',
-                 overwrite_existing: bool = True,
-                 no_record: bool = False,
-                 include: Optional[List[str]] = None,
-                 exclude: Optional[List[str]] = None) -> List[str]:
-        """Download dataset files.
-
-        Args:
-            dsid: Dataset unique identifier
-            file_name: Deprecated. Use include=['pattern'] with glob syntax.
-            output_dir: Directory to save files (default: 'crucible-downloads/')
-            overwrite_existing: Overwrite existing files (default: True)
-            include: Glob patterns - only download matching files
-            exclude: Glob patterns - skip matching files
-
-        Returns:
-            List[str]: Downloaded file paths (including record.json)
-        """
-        if file_name is not None:
-            import warnings
-            warnings.warn(
-                "The 'file_name' parameter is deprecated. Use include=['pattern'] with glob "
-                "syntax instead (e.g. include=['*.h5']). Note: file_name used regex fullmatch; "
-                "glob syntax differs.",
-                DeprecationWarning, stacklevel=2,
-            )
-            all_files = self.list_files(dsid=dsid)
-            matched = [os.path.basename(f.get('storage_path') or f.get('filename', ''))
-                       for f in all_files
-                       if re.fullmatch(fr"({file_name})",
-                                       os.path.basename(f.get('storage_path') or f.get('filename', '')))]
-            include = matched
-
-        return self._client.download(dsid, output_dir=output_dir, no_files=False,
-                                     no_record=no_record,
-                                     overwrite_existing=overwrite_existing,
-                                     include=include, exclude=exclude)
-
-    # Thumbnail Methods
-    def get_thumbnails(self, dsid: str, limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Get thumbnails for a dataset.
-
-        Args:
-            dsid: Dataset unique identifier
-            limit: Maximum number of results to return
-
-        Returns:
-            List[Dict]: Thumbnail objects with base64-encoded images
-        """
-        return self._request('get', f'/datasets/{dsid}/thumbnails')
-
-    def add_thumbnail(self, dsid: str, image, thumbnail_name: Optional[str] = None) -> Dict:
-        """Add a thumbnail to a dataset.
-
-        Args:
-            dsid: Dataset unique identifier
-            image: Image to use as thumbnail. Accepts:
-                - str or Path: path to an image file or a base64-encoded string
-                - PIL.Image.Image: PIL image object
-                - matplotlib.figure.Figure: matplotlib figure
-                - numpy.ndarray: array of shape (H, W) or (H, W, C)
-            thumbnail_name: Display name. Defaults to the filename for file paths,
-                or the dataset ID for in-memory objects.
-
-        Returns:
-            Dict: Created thumbnail object
-        """
-        import base64
-        from ..utils import data2thumbnail, is_base64
-
-        if is_base64(image):
-            thumbnail_data = {
-                'thumbnail_name': thumbnail_name or f"{dsid}_thumbnail",
-                'thumbnail_b64str': image,
-            }
-            return self._request('post', f'/datasets/{dsid}/thumbnails', json=thumbnail_data)
-
-        png_path = data2thumbnail(image)
-
-        if thumbnail_name is None:
-            thumbnail_name = os.path.basename(png_path)
-
-        with open(png_path, 'rb') as f:
-            thumbnail_b64str = base64.b64encode(f.read()).decode('utf-8')
-
-        thumbnail_data = {
-            'thumbnail_name': thumbnail_name,
-            'thumbnail_b64str': thumbnail_b64str,
-        }
-        return self._request('post', f'/datasets/{dsid}/thumbnails', json=thumbnail_data)
-
-    def delete_thumbnail(self, dsid: str, thumbnail_id: int) -> Dict:
-        """Delete a thumbnail from a dataset.
-
-        Args:
-            dsid: Dataset unique identifier
-            thumbnail_id: Integer ID of the thumbnail (from get_thumbnails())
-
-        Returns:
-            Dict: Confirmation message
-        """
-        return self._request('delete', f'/datasets/{dsid}/thumbnails/{thumbnail_id}')
-
-    # Ingestion Methods
-
-    def get_ingestion_requests(self, dsid: Optional[str] = None,
-                               file_id: Optional[str] = None,
-                               limit: int = DEFAULT_LIMIT) -> List[Dict]:
-        """Get ingestion requests, optionally filtered by dataset or file.
-
-        Args:
-            dsid: Filter by dataset ID
-            file_id: Filter by file MFID
-            limit: Maximum number of results
-        """
-        params = {}
-        if dsid:
-            params['dataset_id'] = dsid
-        if file_id:
-            params['file_id'] = file_id
-        return self._request('get', '/ingestion_requests', params=params or None)
-
-    def get_request_status(self, reqid: str) -> Dict:
-        """Get the status of an ingestion request.
-        Args:
-            reqid: Request ID
-        """
-        return self._request('get', f'/ingestion_requests/{reqid}')
-
-
-    def update_ingestion_status(self, reqid: str, status: str,
-                                ingestion_githash: str = None,
-                                ingestion_class: str = None,
-                                timezone: str = "America/Los_Angeles") -> Dict:
-        """Update the status of an ingestion request.
-
-        **Requires admin permissions.**
-
-        Args:
-            reqid: Request ID
-            status: New status ('complete', 'in_progress', 'failed')
-            timezone: Timezone for completion timestamp
-
-        Returns:
-            Dict: Updated ingestion request
-        """
-        from ..utils import get_tz_isoformat
-
-        patch_json = {'ingestion_githash': ingestion_githash,
-                      'ingestion_class': ingestion_class}
-
-        if status == "complete":
-            patch_json.update({"id": reqid, "status": status,
-                                "time_completed": get_tz_isoformat(timezone)})
-        else:
-            patch_json.update({"id": reqid, "status": status})
-
-        return self._request('patch', f'/ingestion_requests/{reqid}', json=patch_json)

--- a/crucible/resources/gcs/__init__.py
+++ b/crucible/resources/gcs/__init__.py
@@ -10,9 +10,12 @@ download : Parallel range-request download from GCS (planned)
 """
 
 from .upload import upload_file_gcs, upload_file_gcs_multipart, upload_file_gcs_resumable
+from .download import bare_name, download_dataset_files
 
 __all__ = [
     'upload_file_gcs',
     'upload_file_gcs_multipart',
     'upload_file_gcs_resumable',
+    'bare_name',
+    'download_dataset_files',
 ]

--- a/crucible/resources/gcs/__init__.py
+++ b/crucible/resources/gcs/__init__.py
@@ -1,0 +1,18 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+GCS transport helpers for Crucible file operations.
+
+Submodules
+----------
+upload   : Resumable and parallel multipart upload to GCS
+download : Parallel range-request download from GCS (planned)
+"""
+
+from .upload import upload_file_gcs, upload_file_gcs_multipart, upload_file_gcs_resumable
+
+__all__ = [
+    'upload_file_gcs',
+    'upload_file_gcs_multipart',
+    'upload_file_gcs_resumable',
+]

--- a/crucible/resources/gcs/download.py
+++ b/crucible/resources/gcs/download.py
@@ -1,0 +1,10 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+GCS download helpers for Crucible datasets.
+
+Planned: parallel range-request download for single large files,
+mirroring the parallel multipart upload strategy.
+"""
+
+# TODO: implement download_file_gcs() using Range headers and ThreadPoolExecutor

--- a/crucible/resources/gcs/download.py
+++ b/crucible/resources/gcs/download.py
@@ -3,8 +3,112 @@
 """
 GCS download helpers for Crucible datasets.
 
-Planned: parallel range-request download for single large files,
-mirroring the parallel multipart upload strategy.
+Standalone functions — take an explicit `client` argument so they can be
+tested in isolation and reused outside of any resource class.
 """
 
-# TODO: implement download_file_gcs() using Range headers and ThreadPoolExecutor
+import fnmatch
+import logging
+import os
+import tempfile
+from concurrent.futures import ThreadPoolExecutor, as_completed
+from typing import Dict, List, Optional
+
+logger = logging.getLogger(__name__)
+
+
+def bare_name(file_record: Dict, dsid: str) -> str:
+    """Extract the display filename from a file record.
+
+    Strips the GCS bucket and dataset prefix from storage_path when present,
+    falls back to the filename field.
+    """
+    sp     = file_record.get('storage_path') or ''
+    prefix = f'mf-storage-prod/{dsid}/'
+    if sp.startswith(prefix):
+        return sp[len(prefix):]
+    if sp:
+        return os.path.basename(sp)
+    return os.path.basename(file_record.get('filename') or '')
+
+
+def download_dataset_files(client, dsid: str, output_dir: str,
+                           link_map: Dict[str, str],
+                           all_files: List[Dict],
+                           overwrite_existing: bool = True,
+                           include: Optional[List[str]] = None,
+                           exclude: Optional[List[str]] = None,
+                           max_workers: int = 4) -> List[str]:
+    """Download ingested files for a dataset into output_dir.
+
+    Args:
+        client:            CrucibleClient instance.
+        dsid:              Dataset unique identifier.
+        output_dir:        Local directory to write files into.
+        link_map:          {mfid: signed_url} from get_download_links().
+        all_files:         List of file records from list_files(dsid).
+        overwrite_existing: Overwrite existing local files (default True).
+        include:           Glob patterns — only download matching filenames.
+        exclude:           Glob patterns — skip matching filenames.
+        max_workers:       Concurrent download threads (default 4).
+
+    Returns:
+        List[str]: Paths of all downloaded files.
+    """
+    # Build (file_record, name, signed_url) candidates using mfid as key
+    candidates = []
+    for f in all_files:
+        name = bare_name(f, dsid)
+        if not name:
+            continue
+        url = link_map.get(f.get('mfid', ''))
+        if url:
+            candidates.append((f, name, url))
+
+    if include:
+        candidates = [(f, n, u) for f, n, u in candidates
+                      if any(fnmatch.fnmatch(n, p) for p in include)]
+    if exclude:
+        candidates = [(f, n, u) for f, n, u in candidates
+                      if not any(fnmatch.fnmatch(n, p) for p in exclude)]
+
+    if not candidates:
+        return []
+
+    def _download_one(args):
+        _, name, signed_url = args
+        download_path = os.path.join(output_dir, name)
+
+        if not overwrite_existing and os.path.exists(download_path):
+            return download_path
+
+        dest_dir = os.path.dirname(download_path) or output_dir
+        os.makedirs(dest_dir, exist_ok=True)
+
+        response = client._session.get(signed_url, stream=True)
+        response.raise_for_status()
+
+        tmp_fd, tmp_path = tempfile.mkstemp(dir=dest_dir)
+        try:
+            with os.fdopen(tmp_fd, 'wb') as fh:
+                for chunk in response.iter_content(chunk_size=1024 * 1024):
+                    fh.write(chunk)
+            os.replace(tmp_path, download_path)
+        except Exception:
+            os.unlink(tmp_path)
+            raise
+
+        logger.debug(f"Downloaded {name}")
+        return download_path
+
+    downloads = []
+    with ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futures = {pool.submit(_download_one, c): c[1] for c in candidates}
+        for future in as_completed(futures):
+            name = futures[future]
+            try:
+                downloads.append(future.result())
+            except Exception as e:
+                logger.error(f"Failed to download {name}: {e}")
+
+    return sorted(downloads)

--- a/crucible/resources/gcs/upload.py
+++ b/crucible/resources/gcs/upload.py
@@ -1,0 +1,232 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+GCS upload helpers for Crucible datasets.
+
+Standalone functions — take an explicit `client` argument rather than `self`
+so they can be tested in isolation and reused outside of any resource class.
+
+Two strategies:
+  - upload_file_gcs_multipart  : parallel XML multipart via google-cloud-storage SDK
+  - upload_file_gcs_resumable  : sequential chunked resumable URI (plain requests)
+
+upload_file_gcs() dispatches between them based on the `multipart` flag.
+"""
+
+import os
+import logging
+import requests
+from typing import Dict, Optional, Tuple
+
+from ...utils.io import hash_file
+
+logger = logging.getLogger(__name__)
+
+
+def upload_file_gcs(client, dsid: str, file_path: str,
+                    multipart: bool = True,
+                    chunk_size_mb: Optional[int] = None,
+                    max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
+    """Dispatch to multipart or resumable upload.
+
+    Args:
+        client:        CrucibleClient instance (provides _request and _config).
+        dsid:          Dataset unique identifier.
+        file_path:     Local path to the file.
+        multipart:     Use parallel multipart (default True); False = sequential resumable.
+        chunk_size_mb: Chunk size in MiB — overrides config if provided.
+        max_workers:   Upload threads — overrides config if provided.
+
+    Returns:
+        Tuple[Dict, bool]: (AssociatedFileRead record, was_existing).
+            was_existing is True when the file was a dedup hit and the upload was skipped.
+    """
+    if multipart:
+        return upload_file_gcs_multipart(client, dsid, file_path,
+                                         chunk_size_mb=chunk_size_mb,
+                                         max_workers=max_workers)
+    return upload_file_gcs_resumable(client, dsid, file_path)
+
+
+def upload_file_gcs_multipart(client, dsid: str, file_path: str,
+                               chunk_size_mb: Optional[int] = None,
+                               max_workers: Optional[int] = None) -> Tuple[Dict, bool]:
+    """Parallel multipart upload via the GCS SDK (upload_chunks_concurrently).
+
+    The Crucible API vends a short-lived OAuth2 token via
+    POST /datasets/{dsid}/upload/initiate/multipart so no GCS credentials
+    are required on the client side.
+
+    Args:
+        client:        CrucibleClient instance.
+        dsid:          Dataset unique identifier.
+        file_path:     Local path to the file.
+        chunk_size_mb: Part size in MiB (default from config: 64 MiB).
+        max_workers:   Concurrent upload threads (default from config: 8).
+
+    Returns:
+        Tuple[Dict, bool]: (AssociatedFileRead, was_existing).
+    """
+    from google.cloud import storage
+    from google.cloud.storage import transfer_manager
+    from google.oauth2.credentials import Credentials
+
+    cfg      = client._config
+    _CHUNK   = (chunk_size_mb or cfg.upload_chunk_size_mb) * 1024 * 1024
+    _WORKERS = max_workers or cfg.upload_max_workers
+
+    file_size = os.path.getsize(file_path)
+    filename  = os.path.basename(file_path)
+
+    logger.info(f"Uploading {filename} ({file_size / 1024**2:.1f} MB) "
+                f"to dataset {dsid} [parallel, {_WORKERS} workers]")
+
+    sha256_hash, local_crc32c_b64 = hash_file(file_path, block_size=_CHUNK)
+
+    init = client._request('post', f'/datasets/{dsid}/upload/initiate/multipart',
+                           json={'filename': filename, 'size': file_size,
+                                 'sha256_hash': sha256_hash})
+
+    if init.get('existing_file') is not None:
+        logger.info(f"{filename} already exists in dataset {dsid}, skipping upload")
+        return init['existing_file'], True
+
+    upload_id = init['upload_id']
+
+    gcs = storage.Client(
+        credentials=Credentials(token=init['access_token']),
+        project=init['project'],
+    )
+    blob = gcs.bucket(init['bucket']).blob(f"{init['object_prefix']}{filename}")
+
+    logger.debug(f"Starting parallel upload: upload_id={upload_id}, "
+                 f"chunk={_CHUNK >> 20} MiB, workers={_WORKERS}")
+
+    # No per-chunk checksum — known SDK bug (sends CRC32C in a way GCS rejects).
+    # We verify the final assembled object below instead, which is a stronger guarantee.
+    transfer_manager.upload_chunks_concurrently(
+        file_path,
+        blob,
+        chunk_size=_CHUNK,
+        max_workers=_WORKERS,
+        worker_type=transfer_manager.THREAD,
+    )
+
+    # Verify assembled object CRC32C against our local hash.
+    blob.reload()
+    if blob.crc32c and blob.crc32c != local_crc32c_b64:
+        raise RuntimeError(
+            f"CRC32C mismatch for {filename} after assembly: "
+            f"local={local_crc32c_b64} gcs={blob.crc32c}"
+        )
+    logger.debug(f"CRC32C verified: {local_crc32c_b64}")
+
+    logger.info(f"Completing upload for {filename} (upload_id={upload_id})")
+    file_record = client._request('post', f'/datasets/{dsid}/upload/complete',
+                                  json={'upload_id': upload_id, 'sha256_hash': sha256_hash})
+    return file_record, False
+
+
+def upload_file_gcs_resumable(client, dsid: str, file_path: str) -> Tuple[Dict, bool]:
+    """Sequential chunked resumable upload via a GCS resumable session URI.
+
+    Does not require the google-cloud-storage SDK. The Crucible API initiates
+    the resumable session and returns a signed URI; chunks are PUT directly
+    to GCS using plain requests.
+
+    Args:
+        client:    CrucibleClient instance.
+        dsid:      Dataset unique identifier.
+        file_path: Local path to the file.
+
+    Returns:
+        Tuple[Dict, bool]: (AssociatedFileRead, was_existing).
+    """
+    _256K        = 256 * 1024
+    _MIN_CHUNK   = 32 * 1024 * 1024   # 32 MiB floor
+    _MAX_RETRIES = 3
+
+    file_size = os.path.getsize(file_path)
+    filename  = os.path.basename(file_path)
+
+    logger.info(f"Uploading {filename} ({file_size / 1024**2:.1f} MB) to dataset {dsid}")
+
+    sha256_hash, local_crc32c_b64 = hash_file(file_path, block_size=_MIN_CHUNK)
+
+    init = client._request('post', f'/datasets/{dsid}/upload/initiate',
+                           json={'filename': filename, 'size': file_size,
+                                 'sha256_hash': sha256_hash})
+
+    if init.get('existing_file') is not None:
+        logger.info(f"File {filename} already exists in dataset {dsid}, skipping upload")
+        return init['existing_file'], True
+
+    upload_id  = init['upload_id']
+    uri        = init['resumable_uri']
+    raw_hint   = init.get('chunk_size_hint', _MIN_CHUNK)
+    chunk_size = max((max(raw_hint, _MIN_CHUNK) // _256K) * _256K, _256K)
+
+    logger.debug(f"Chunked upload initiated: upload_id={upload_id}, "
+                 f"chunk_size={chunk_size >> 20} MiB")
+
+    with open(file_path, 'rb') as f:
+        offset = 0
+        while offset < file_size:
+            f.seek(offset)
+            chunk     = f.read(chunk_size)
+            chunk_end = offset + len(chunk) - 1
+
+            for attempt in range(_MAX_RETRIES):
+                resp = requests.put(
+                    uri,
+                    data=chunk,
+                    headers={
+                        'Content-Range': f'bytes {offset}-{chunk_end}/{file_size}',
+                        'Content-Length': str(len(chunk)),
+                    },
+                    timeout=120,
+                )
+                if resp.status_code in (200, 201):
+                    try:
+                        remote_crc32c = resp.json().get('crc32c')
+                    except ValueError:
+                        remote_crc32c = None
+                    if remote_crc32c and remote_crc32c != local_crc32c_b64:
+                        raise RuntimeError(
+                            f"GCS crc32c mismatch for {filename}: "
+                            f"local={local_crc32c_b64} remote={remote_crc32c}"
+                        )
+                    offset = file_size
+                    break
+                elif resp.status_code == 308:
+                    offset = chunk_end + 1
+                    logger.debug(f"Chunk accepted, offset={offset}/{file_size}")
+                    break
+                else:
+                    logger.warning(
+                        f"{filename} GCS chunk rejected offset={offset} "
+                        f"status={resp.status_code} attempt={attempt+1}/{_MAX_RETRIES} "
+                        f"body={resp.text[:300]}"
+                    )
+                    if attempt == _MAX_RETRIES - 1:
+                        raise RuntimeError(
+                            f"GCS chunk upload failed after {_MAX_RETRIES} attempts "
+                            f"(status {resp.status_code}): {resp.text}"
+                        )
+                    probe = requests.put(uri,
+                                         headers={'Content-Range': f'bytes */{file_size}'},
+                                         timeout=30)
+                    if probe.status_code in (200, 201):
+                        offset = file_size
+                        break
+                    elif probe.status_code == 308 and 'Range' in probe.headers:
+                        last_byte = int(probe.headers['Range'].split('-')[1])
+                        offset = last_byte + 1
+                    f.seek(offset)
+                    chunk     = f.read(chunk_size)
+                    chunk_end = offset + len(chunk) - 1
+
+    logger.info(f"Completing upload for {filename} (upload_id={upload_id})")
+    file_record = client._request('post', f'/datasets/{dsid}/upload/complete',
+                                  json={'upload_id': upload_id, 'sha256_hash': sha256_hash})
+    return file_record, False

--- a/crucible/resources/ingestion.py
+++ b/crucible/resources/ingestion.py
@@ -1,0 +1,82 @@
+#!/usr/bin/env python3
+# -*- coding: utf-8 -*-
+"""
+Ingestion request operations for the Crucible API.
+
+Access via: client.ingestion.list(), client.ingestion.get(), etc.
+"""
+
+import logging
+from typing import Dict, List, Optional
+
+from .base import BaseResource
+from ..constants import DEFAULT_LIMIT
+
+logger = logging.getLogger(__name__)
+
+
+class IngestionOperations(BaseResource):
+    """Operations on ingestion requests (/ingestion_requests endpoints).
+
+    Access via: client.ingestion.list(), client.ingestion.get(), etc.
+    """
+
+    def list(self, dsid: Optional[str] = None,
+             file_id: Optional[str] = None,
+             limit: int = DEFAULT_LIMIT) -> List[Dict]:
+        """List ingestion requests, optionally filtered by dataset or file.
+
+        Args:
+            dsid: Filter by dataset ID
+            file_id: Filter by file MFID
+            limit: Maximum number of results
+
+        Returns:
+            List[Dict]: IngestionRequest records
+        """
+        params = {}
+        if dsid:
+            params['dataset_id'] = dsid
+        if file_id:
+            params['file_id'] = file_id
+        return self._request('get', '/ingestion_requests', params=params or None)
+
+    def get(self, request_id: str) -> Dict:
+        """Get the status of a single ingestion request.
+
+        Args:
+            request_id: Ingestion request ID
+
+        Returns:
+            Dict: IngestionRequest record (id, status, ...)
+        """
+        return self._request('get', f'/ingestion_requests/{request_id}')
+
+    def update(self, request_id: str, status: str,
+               ingestion_githash: Optional[str] = None,
+               ingestion_class: Optional[str] = None,
+               timezone: str = "America/Los_Angeles") -> Dict:
+        """Update the status of an ingestion request. Admin only.
+
+        Args:
+            request_id: Ingestion request ID
+            status: New status ('complete', 'in_progress', 'failed')
+            ingestion_githash: Git hash of the ingestion worker version
+            ingestion_class: Ingestion class used
+            timezone: Timezone for the completion timestamp
+
+        Returns:
+            Dict: Updated IngestionRequest record
+        """
+        from ..utils import get_tz_isoformat
+
+        patch_json = {
+            'id': request_id,
+            'status': status,
+            'ingestion_githash': ingestion_githash,
+            'ingestion_class': ingestion_class,
+        }
+        if status == "complete":
+            patch_json["time_completed"] = get_tz_isoformat(timezone)
+
+        return self._request('patch', f'/ingestion_requests/{request_id}', json=patch_json)

--- a/crucible/resources/ingestion.py
+++ b/crucible/resources/ingestion.py
@@ -40,7 +40,7 @@ class IngestionOperations(BaseResource):
             params['dataset_id'] = dsid
         if file_id:
             params['file_id'] = file_id
-        return self._request('get', '/ingestion_requests', params=params or None)
+        return self._paginate('/ingestion_requests', params, limit=limit)
 
     def get(self, request_id: str) -> Dict:
         """Get the status of a single ingestion request.

--- a/crucible/resources/ingestion.py
+++ b/crucible/resources/ingestion.py
@@ -7,6 +7,7 @@ Access via: client.ingestion.list(), client.ingestion.get(), etc.
 """
 
 import logging
+import time
 from typing import Dict, List, Optional
 
 from .base import BaseResource
@@ -51,6 +52,25 @@ class IngestionOperations(BaseResource):
             Dict: IngestionRequest record (id, status, ...)
         """
         return self._request('get', f'/ingestion_requests/{request_id}')
+
+    def wait(self, request_id: str, sleep_interval: int = 1) -> Dict:
+        """Poll an ingestion request until it reaches a terminal state.
+
+        Args:
+            request_id: Ingestion request ID
+            sleep_interval: Seconds between status checks (default 1)
+
+        Returns:
+            Dict: Final IngestionRequest record
+        """
+        req = self.get(request_id)
+        logger.info("Waiting for ingestion request to complete...")
+        while req['status'] in ('requested', 'started'):
+            time.sleep(sleep_interval)
+            req = self.get(request_id)
+            logger.info(f"Current status: {req['status']}")
+        logger.info(f"Request completed with status: {req['status']}")
+        return req
 
     def update(self, request_id: str, status: str,
                ingestion_githash: Optional[str] = None,

--- a/crucible/resources/instruments.py
+++ b/crucible/resources/instruments.py
@@ -117,33 +117,21 @@ class InstrumentOperations(BaseResource):
         """
         return self._request('patch', f'/instruments/{unique_id}', json=kwargs)
 
-    def add_scientific_metadata(self, instrument_id: str, metadata: Dict) -> Dict:
-        """Create scientific metadata for an instrument.
+    def search(self, q: str, limit: int = 20) -> List[Dict]:
+        """Fuzzy search across instruments. Available to all authenticated users.
+
+        Matches against instrument_name, instrument_type, and manufacturer
+        (best score across the three).
 
         Args:
-            instrument_id (str): Instrument unique identifier
-            metadata (Dict): Scientific metadata dictionary
+            q: Search term (min 3 chars). Typo-tolerant.
+            limit: Max results (default 20, max 50).
 
         Returns:
-            Dict: Created metadata object
+            List[Dict]: Matching instrument records, ranked by relevance.
         """
-        return self._request('post', f'/resources/{instrument_id}/metadata', json=metadata)
-
-    def update_scientific_metadata(self, instrument_id: str, metadata: Dict,
-                                   overwrite: bool = False) -> Dict:
-        """Update scientific metadata for an instrument.
-
-        Args:
-            instrument_id (str): Instrument unique identifier
-            metadata (Dict): Scientific metadata dictionary
-            overwrite (bool): If True, replace all metadata (POST); if False, merge with existing (PATCH)
-
-        Returns:
-            Dict: Updated metadata object
-        """
-        if overwrite:
-            return self._request('post', f'/resources/{instrument_id}/metadata', json=metadata)
-        return self._request('patch', f'/resources/{instrument_id}/metadata', json=metadata)
+        result = self._request('get', '/instruments/search', params={'q': q, 'limit': limit})
+        return result.get('items', result) if isinstance(result, dict) else result
 
     def get_or_create(self, instrument_name: str, location: Optional[str] = None,
                      instrument_owner: Optional[str] = None) -> Dict:

--- a/crucible/resources/projects.py
+++ b/crucible/resources/projects.py
@@ -99,34 +99,6 @@ class ProjectOperations(BaseResource):
             self.update_scientific_metadata(result['project_id'], scientific_metadata)
         return result
 
-    def add_scientific_metadata(self, project_id: str, metadata: Dict) -> Dict:
-        """Create scientific metadata for a project.
-
-        Args:
-            project_id (str): Project unique identifier
-            metadata (Dict): Scientific metadata dictionary
-
-        Returns:
-            Dict: Created metadata object
-        """
-        return self._request('post', f'/resources/{project_id}/metadata', json=metadata)
-
-    def update_scientific_metadata(self, project_id: str, metadata: Dict,
-                                   overwrite: bool = False) -> Dict:
-        """Update scientific metadata for a project.
-
-        Args:
-            project_id (str): Project unique identifier
-            metadata (Dict): Scientific metadata dictionary
-            overwrite (bool): If True, replace all metadata (POST); if False, merge (PATCH)
-
-        Returns:
-            Dict: Updated metadata object
-        """
-        if overwrite:
-            return self._request('post', f'/resources/{project_id}/metadata', json=metadata)
-        return self._request('patch', f'/resources/{project_id}/metadata', json=metadata)
-
     def get_users(self, project_id: str, limit: int = DEFAULT_LIMIT,
                   offset: int = 0) -> List[Dict]:
         """Get users associated with a project.
@@ -213,6 +185,22 @@ class ProjectOperations(BaseResource):
                 params['username'] = username
             return self._request('post', f'/projects/{project_id}/users/me', params=params)
         return self._request('post', f'/projects/{project_id}/users/{orcid}')
+
+    def search(self, q: str, limit: int = 20) -> List[Dict]:
+        """Fuzzy search across projects. Available to all authenticated users.
+
+        Matches against both title and project_id. Returns only projects
+        the caller is a member of.
+
+        Args:
+            q: Search term (min 3 chars). Typo-tolerant.
+            limit: Max results (default 20, max 50).
+
+        Returns:
+            List[Dict]: Matching ProjectRead records, ranked by relevance.
+        """
+        result = self._request('get', '/projects/search', params={'q': q, 'limit': limit})
+        return result.get('items', result) if isinstance(result, dict) else result
 
     def get_or_create(self, project_id: str, get_project_info_function=_build_project_from_args,
                      **kwargs) -> Dict:

--- a/crucible/resources/samples.py
+++ b/crucible/resources/samples.py
@@ -355,6 +355,27 @@ class SampleOperations(BaseResource):
         """
         return self._request('post', f"/samples/{parent_id}/children/{child_id}")
 
+    def search(self, q: str, project_id: Optional[str] = None,
+               limit: int = 20) -> List[Dict]:
+        """Fuzzy name search across samples. Available to all authenticated users.
+
+        Matches against sample_name. Returns samples the caller can read.
+        For scientific metadata search use search_metadata().
+
+        Args:
+            q: Search term (min 3 chars). Typo-tolerant.
+            project_id: Optional project to scope results to.
+            limit: Max results (default 20, max 50).
+
+        Returns:
+            List[Dict]: Matching SampleResponse records, ranked by relevance.
+        """
+        params = {'q': q, 'limit': limit}
+        if project_id:
+            params['project_id'] = project_id
+        result = self._request('get', '/samples/search', params=params)
+        return result.get('items', result) if isinstance(result, dict) else result
+
     def graph(self, sample_id: str, recursive: bool = False, as_networkx: bool = False):
         """Return the graph of entities connected to this sample.
 
@@ -369,3 +390,25 @@ class SampleOperations(BaseResource):
             dict | networkx.DiGraph: Node-link graph data.
         """
         return self._client.graphs.get(sample_id, recursive=recursive, as_networkx=as_networkx)
+
+    def download(self, sample_id: str, output_dir: str = 'crucible-downloads') -> List[str]:
+        """Save the sample record as record.json.
+
+        Args:
+            sample_id: Sample unique identifier
+            output_dir: Directory to save the record (default: 'crucible-downloads/')
+
+        Returns:
+            List[str]: Path to the saved record.json
+        """
+        import json as _json
+        import os
+
+        record     = self.get(sample_id, include_metadata=True)
+        record_dir = os.path.join(output_dir, sample_id)
+        os.makedirs(record_dir, exist_ok=True)
+        json_path  = os.path.join(record_dir, 'record.json')
+        with open(json_path, 'w') as fh:
+            _json.dump(record, fh, indent=2)
+        logger.info(f"Saved record to {json_path}")
+        return [json_path]

--- a/crucible/resources/users.py
+++ b/crucible/resources/users.py
@@ -74,7 +74,8 @@ class UserOperations(BaseResource):
         Returns:
             List[Dict]: Matching users (username, first_name, last_name, orcid)
         """
-        return self._request('get', '/users/search', params={'q': q})
+        result = self._request('get', '/users/search', params={'q': q})
+        return result.get('items', result) if isinstance(result, dict) else result
 
     @_deprecated("client.account.profile()")
     def me(self) -> Dict:

--- a/crucible/utils/__init__.py
+++ b/crucible/utils/__init__.py
@@ -9,7 +9,7 @@ io          : File I/O, hashing, time, and image helpers
 deprecation : API lifecycle decorators (_deprecated, _removed)
 """
 
-from .io import run_shell, checkhash, get_tz_isoformat, check_small_files, is_base64, data2thumbnail, parse_timestamp
+from .io import run_shell, checkhash, get_tz_isoformat, check_small_files, is_base64, data2thumbnail, parse_timestamp, hash_file
 from .deprecation import _deprecated, _removed
 
 __all__ = [
@@ -21,6 +21,7 @@ __all__ = [
     'check_small_files',
     'is_base64',
     'data2thumbnail',
+    'hash_file',
     # deprecation
     '_deprecated',
     '_removed',

--- a/crucible/utils/io.py
+++ b/crucible/utils/io.py
@@ -73,6 +73,26 @@ def get_tz_isoformat(timezone="America/Los_Angeles"):
     return curr_pct_time
 
 
+def hash_file(file_path: str, block_size: int = 32 * 1024 * 1024):
+    """Compute SHA256 and CRC32C of a file in a single pass.
+
+    Args:
+        file_path: Path to the file.
+        block_size: Read block size in bytes (default 32 MiB).
+
+    Returns:
+        Tuple[str, str]: (sha256_hex, crc32c_base64)
+    """
+    import google_crc32c
+    sha = hashlib.sha256()
+    crc = google_crc32c.Checksum()
+    with open(file_path, 'rb') as f:
+        for block in iter(lambda: f.read(block_size), b''):
+            sha.update(block)
+            crc.update(block)
+    return sha.hexdigest(), base64.b64encode(crc.digest()).decode()
+
+
 def parse_timestamp(value: str) -> str:
     """Parse a human-readable date/time string and return an ISO 8601 string.
 

--- a/docs/api-reference/account.md
+++ b/docs/api-reference/account.md
@@ -1,0 +1,12 @@
+# AccountOperations
+
+Access via `client.account`. Self-service operations — no admin required.
+
+::: crucible.resources.account.AccountOperations
+    options:
+      members:
+        - whoami
+        - profile
+        - update_profile
+        - api_key
+        - verify

--- a/docs/api-reference/client.md
+++ b/docs/api-reference/client.md
@@ -14,11 +14,14 @@ client = CrucibleClient(api_url="https://crucible.lbl.gov/api/v2", api_key="your
 
 | Attribute | Type | Description |
 |---|---|---|
-| `client.datasets` | `DatasetOperations` | Dataset CRUD, file upload, metadata, ingestion |
+| `client.datasets` | `DatasetOperations` | Dataset CRUD, file upload/download, thumbnails, metadata |
 | `client.samples` | `SampleOperations` | Sample CRUD, hierarchies, dataset links |
 | `client.projects` | `ProjectOperations` | Project CRUD, user management |
 | `client.instruments` | `InstrumentOperations` | Instrument CRUD |
 | `client.users` | `UserOperations` | User management (admin) |
+| `client.files` | `FileOperations` | File lookup, download, and ingestion by MFID |
+| `client.account` | `AccountOperations` | Self-service profile, API key, verification |
+| `client.ingestions` | `IngestionOperations` | Ingestion request management |
 | `client.graphs` | `GraphOperations` | Entity graph traversal |
 | `client.deletions` | `DeletionOperations` | Deletion request management |
 
@@ -29,10 +32,10 @@ client = CrucibleClient(api_url="https://crucible.lbl.gov/api/v2", api_key="your
       members:
         - __init__
         - health
+        - live
         - whoami
         - get
         - get_resource_type
         - get_links
         - link
         - unlink
-        - download

--- a/docs/api-reference/datasets.md
+++ b/docs/api-reference/datasets.md
@@ -2,25 +2,29 @@
 
 Access via `client.datasets`.
 
+File operations are also available via `client.files` (by MFID) and ingestion via `client.ingestions`.
+
 ::: crucible.resources.datasets.DatasetOperations
     options:
       members:
         - get
         - list
+        - count
+        - search
         - create
         - update
         - delete
-        - upload_file
+        - add_file
+        - list_files
         - get_download_links
         - download
-        - add_associated_file
-        - get_associated_files
         - get_scientific_metadata
         - update_scientific_metadata
         - replace_scientific_metadata
-        - search_scientific_metadata
+        - search_metadata
         - add_thumbnail
         - get_thumbnails
+        - delete_thumbnail
         - add_keyword
         - get_keywords
         - add_sample
@@ -29,5 +33,6 @@ Access via `client.datasets`.
         - remove_child
         - list_parents
         - list_children
-        - request_ingestion
+        - get_access_groups
+        - add_access_group
         - graph

--- a/docs/api-reference/files.md
+++ b/docs/api-reference/files.md
@@ -1,0 +1,15 @@
+# FileOperations
+
+Access via `client.files`. Operates on individual files by MFID.
+
+For dataset-scoped file operations (upload, bulk download) use `client.datasets`.
+For ingestion management use `client.ingestions`.
+
+::: crucible.resources.files.FileOperations
+    options:
+      members:
+        - get
+        - list
+        - download
+        - get_download_link
+        - request_ingestion

--- a/docs/api-reference/ingestion.md
+++ b/docs/api-reference/ingestion.md
@@ -7,4 +7,5 @@ Access via `client.ingestions`.
       members:
         - list
         - get
+        - wait
         - update

--- a/docs/api-reference/ingestion.md
+++ b/docs/api-reference/ingestion.md
@@ -1,0 +1,10 @@
+# IngestionOperations
+
+Access via `client.ingestions`.
+
+::: crucible.resources.ingestion.IngestionOperations
+    options:
+      members:
+        - list
+        - get
+        - update

--- a/docs/api-reference/users.md
+++ b/docs/api-reference/users.md
@@ -5,11 +5,15 @@ Access via `client.users`.
 !!! note
     Most user management operations require admin privileges.
 
+For self-service profile and API key operations see `client.account`.
+
 ::: crucible.resources.users.UserOperations
     options:
       members:
         - get
+        - search
         - list
+        - resolve
         - create
         - update
         - list_datasets
@@ -18,3 +22,4 @@ Access via `client.users`.
         - add_to_access_group
         - remove_from_access_group
         - list_projects
+        - verify_api_key

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,100 @@
 # Changelog
 
+## 3.0.0
+
+This is a major release. The flat `client.*` API that was deprecated in 2.x has been
+removed. All operations now live under typed resource namespaces.
+
+!!! danger "Breaking changes"
+    **Before upgrading**, update any code that uses the old flat API:
+
+    | Old (removed) | New |
+    |---|---|
+    | `client.get_dataset(dsid)` | `client.datasets.get(dsid)` |
+    | `client.create_new_dataset(...)` | `client.datasets.create(...)` |
+    | `client.list_datasets(...)` | `client.datasets.list(...)` |
+    | `client.get_sample(sid)` | `client.samples.get(sid)` |
+    | `client.add_sample(...)` | `client.samples.create(...)` |
+    | `client.list_samples(...)` | `client.samples.list(...)` |
+    | `client.get_project(pid)` | `client.projects.get(pid)` |
+    | `client.get_user(orcid=...)` | `client.users.get(orcid=...)` |
+    | `client.download(resource_id)` | `client.datasets.download(dsid)` or `client.samples.download(sid)` |
+    | `pip install nano-crucible[shell]` | `pip install nano-crucible` (now core) |
+    | `pip install nano-crucible[gcs]` | `pip install nano-crucible` (now core) |
+    | `pip install nano-crucible[all]` | `pip install nano-crucible` |
+
+### New resource namespaces
+
+- **`client.account`** — self-service profile management (`profile()`, `update_profile()`,
+  `api_key()`, `verify()`, `whoami()`). No admin required.
+- **`client.ingestions`** — ingestion request management (`list()`, `get()`, `wait()`, `update()`).
+- **`client.files`** is now a proper peer resource (previously a base class for `DatasetOperations`).
+  Scoped to file MFIDs: `get()`, `list()`, `download()`, `get_download_link()`, `request_ingestion()`.
+
+### Architecture changes
+
+- `DatasetOperations` no longer inherits from `FileOperations`. All dataset-scoped file
+  operations (`add_file`, `list_files`, `get_download_links`, `download`, thumbnails,
+  ingestion) now live directly on `DatasetOperations`.
+- Upload logic extracted to `crucible/resources/gcs/upload.py` — standalone functions
+  testable in isolation.
+- Download logic extracted to `crucible/resources/gcs/download.py` — parallel file downloads
+  via `ThreadPoolExecutor`.
+- Scientific metadata methods (`search_metadata`, `get_scientific_metadata`,
+  `update_scientific_metadata`, `get_access_groups`, `add_access_group`) unified on
+  `BaseResource` — available on all resource types.
+- `search_scientific_metadata()` renamed to `search_metadata()` (deprecated alias kept).
+
+### New features
+
+- **Parallel GCS multipart upload** — `add_file()` uses `transfer_manager.upload_chunks_concurrently()`
+  by default (8 workers, 64 MiB chunks, benchmarked). Falls back to sequential resumable upload
+  with `multipart=False`. Upload settings configurable via `crucible config set upload_chunk_size_mb`
+  and `upload_max_workers`.
+- **Parallel dataset downloads** — `_fetch_files` now downloads concurrently (4 workers).
+- **Fuzzy name search** — `datasets.search(q)`, `samples.search(q)`, `projects.search(q)`,
+  `instruments.search(q)` via new API endpoints. Typo-tolerant, returns top-N by relevance.
+- **Scientific metadata search** renamed — `search_metadata(q)` on all resources.
+- **Username support** — `users.get(username=...)`, `users.search(q)`, `user set-username`,
+  `project add-user -u USERNAME`.
+- **`samples.download(sid)`** — saves sample record as `record.json`.
+- **`files.download(file_id)`** — single-file download by MFID.
+- **`ingestions.wait(request_id)`** — public polling method.
+
+### Packaging
+
+- `google-cloud-storage>=2.7.0` and `prompt_toolkit>=3.0` moved to core dependencies.
+- `[shell]`, `[gcs]`, and `[all]` extras removed — `pip install nano-crucible` installs everything.
+- `[parsers]` remains optional (ASE/LAMMPS support).
+
+### CLI additions
+
+- `crucible account` — `show`, `edit`, `update`, `api-key`, `verify`
+- `crucible ingestion` — `list`, `get`, `wait`
+- `crucible user search TERM` — non-admin user lookup
+- `crucible {dataset,sample,project,instrument} search TERM` — fuzzy name search
+- `crucible {dataset,sample,project,instrument} search-metadata TERM` (also `search-md`)
+- `crucible dataset list-access-groups`, `add-access-group`
+- `crucible user add-access-group`, `remove-access-group`
+- `crucible deletion list-deleted`, `get-deleted`, `delete --force`
+- `--json` flag on all `get` and `list` commands (replaces `--output json`)
+- `sample update` — named flags (`-n`, `-t`, `--description`, `--project`, `--public`)
+
+### Deprecations (still work, emit warnings)
+
+- `client.download()` → `client.datasets.download()` or `client.samples.download()`
+- `datasets.get_associated_files()` → `datasets.list_files()`
+- `datasets.search_scientific_metadata()` → `datasets.search_metadata()`
+- `datasets.add_file_to_dataset()` → `datasets.add_file()`
+- `datasets.graph()` → `client.graphs.get()`
+- `datasets.get_ingestion_requests()` → `client.ingestions.list()`
+- `datasets.get_request_status()` → `client.ingestions.get()`
+- `datasets.update_ingestion_status()` → `client.ingestions.update()`
+- `users.me()` → `client.account.profile()`
+- `users.get_api_key()` → `client.account.api_key()`
+
+---
+
 ## 2.1.0 → 2.1.2
 
 Although versioned as a patch series, this span (late March to mid-May) is effectively a

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -16,13 +16,9 @@ pip install nano-crucible
 ```bash
 # Parser support (includes ASE for LAMMPS/MatEnsemble parsers)
 pip install nano-crucible[parsers]
-
-# Interactive shell with tab-completion
-pip install nano-crucible[shell]
-
-# Everything (recommended)
-pip install nano-crucible[all]
 ```
+
+> **Note:** `google-cloud-storage` (GCS parallel upload) and `prompt_toolkit` (interactive shell) are included as core dependencies — no extra needed.
 
 ### Development install
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -83,6 +83,9 @@ nav:
     - Projects: api-reference/projects.md
     - Instruments: api-reference/instruments.md
     - Users: api-reference/users.md
+    - Files: api-reference/files.md
+    - Account: api-reference/account.md
+    - Ingestion: api-reference/ingestion.md
     - Graphs: api-reference/graphs.md
     - Models: api-reference/models.md
   - Changelog: changelog.md


### PR DESCRIPTION
## Summary

This is the v3.0.0 release branch. See `docs/changelog.md` for the full changelog.

**Breaking changes:**
- All flat deprecated methods removed from `CrucibleClient` (e.g. `client.get_dataset()`, `client.add_sample()`, ~50 others)
- `DatasetOperations` no longer inherits `FileOperations`
- `[shell]`, `[gcs]`, `[all]` extras removed — now core dependencies

**New:**
- `client.account` — self-service profile/API key management
- `client.ingestions` + `crucible ingestion list/get/wait`
- `client.files` as a proper peer resource
- Parallel GCS multipart upload (8 workers, 64 MiB chunks)
- Parallel dataset downloads
- Fuzzy name search on all resources
- Username support throughout
- `crucible account` subcommand
- `search-metadata`/`search-md` commands on all resources
- `crucible ingestion` subcommand