### PR TITLE
Fix 3.0.1: dataset download path

### DIFF
--- a/crucible/__init__.py
+++ b/crucible/__init__.py
@@ -7,7 +7,7 @@ Python client library for the Crucible API - the Molecular Foundry data
 management system.
 """
 
-__version__ = "3.0.0"
+__version__ = "3.0.1"
 __author__ = "mkywall","roncofaber"
 
 import logging

--- a/crucible/resources/datasets.py
+++ b/crucible/resources/datasets.py
@@ -516,12 +516,14 @@ class DatasetOperations(BaseResource):
             downloaded.append(json_path)
 
         if not no_files:
-            files = self._fetch_files(dsid, output_dir=output_dir,
+            dest = os.path.join(output_dir, dsid)
+            os.makedirs(dest, exist_ok=True)
+            files = self._fetch_files(dsid, output_dir=dest,
                                       overwrite_existing=overwrite_existing,
                                       include=include, exclude=exclude)
             downloaded.extend(files)
             if files:
-                logger.info(f"Downloaded {len(files)} file(s) to {output_dir}")
+                logger.info(f"Downloaded {len(files)} file(s) to {dest}")
 
         return downloaded
 

--- a/docs/changelog.md
+++ b/docs/changelog.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## 3.0.1
+
+- Fix `datasets.download()`: data files now saved inside `output_dir/{dsid}/` alongside `record.json`, not directly in `output_dir/`.
+
 ## 3.0.0
 
 This is a major release. The flat `client.*` API that was deprecated in 2.x has been


### PR DESCRIPTION
Data files were being saved to `output_dir/` instead of `output_dir/{dsid}/`, while `record.json` was already correctly placed in `output_dir/{dsid}/`. Both now land in the same subdirectory.