### PR TITLE
CI: trigger PyPI publish on GitHub release

### DIFF
--- a/.github/workflows/manual-publish-to-pypi.yml
+++ b/.github/workflows/manual-publish-to-pypi.yml
@@ -1,20 +1,22 @@
 name: Publish Python distribution to PyPI
 
 on:
+  release:
+    types: [published]
   workflow_dispatch
-    
+
 jobs:
   build:
     name: Build distribution
     runs-on: ubuntu-latest
-  
+
     steps:
         - uses: actions/checkout@v4
           with:
             fetch-depth: 0
         - name: Check version matches tag
           run: |
-            TAG_VERSION=$(git describe --tags --abbrev=0 | sed 's/^v//')
+            TAG_VERSION=$(echo "${{ github.ref_name }}" | sed 's/^v//')
             INIT_VERSION=$(grep -Po '(?<=__version__ = ")[^"]*' crucible/__init__.py)
             if [ "$TAG_VERSION" != "$INIT_VERSION" ]; then
               echo "Version mismatch: tag=$TAG_VERSION, __init__.py=$INIT_VERSION"


### PR DESCRIPTION
Adds `release: published` trigger so publishing fires automatically when a GitHub release is created. Keeps `workflow_dispatch` as a manual fallback. Also simplifies the version check to use `github.ref_name` instead of `git describe`.